### PR TITLE
fix: quand une action passe de FAITE/ANNULÉE à A FAIRE, on retire la la date `completedAt`

### DIFF
--- a/dashboard/src/components/ActionModal.js
+++ b/dashboard/src/components/ActionModal.js
@@ -145,7 +145,11 @@ function ActionContent({ onClose, action, personId = null, personIds = null, isM
 
   const handleCreateAction = async () => {
     const handlePostNewAction = async (body) => {
-      if (body.status !== TODO) body.completedAt = body.completedAt || Date.now();
+      if ([DONE, CANCEL].includes(data.status)) {
+        body.completedAt = body.completedAt || now();
+      } else {
+        body.completedAt = null;
+      }
       const response = await API.post({ path: '/action', body: prepareActionForEncryption(body) });
       if (response.ok) setActions((actions) => [response.decryptedData, ...actions]);
       const { createdAt } = response.decryptedData;
@@ -274,15 +278,10 @@ function ActionContent({ onClose, action, personId = null, personIds = null, isM
     const body = { ...data };
     body.teams = Array.isArray(data.teams) ? data.teams : [data.team];
     if (!data.teams?.length) return toast.error('Une action doit être associée à au moins une équipe.');
-    const statusChanged = data.status && action.status !== data.status;
-    if (statusChanged) {
-      if ([DONE, CANCEL].includes(data.status)) {
-        // When status changed to finished (done, cancel) completedAt we set it to now if not set.
-        body.completedAt = data.completedAt || now();
-      } else {
-        // When status just changed to "todo" we set completedAt to null (since it's not done yet).
-        body.completedAt = null;
-      }
+    if ([DONE, CANCEL].includes(data.status)) {
+      body.completedAt = data.completedAt || now();
+    } else {
+      body.completedAt = null;
     }
     if (data.completedAt && outOfBoundariesDate(data.completedAt)) return toast.error('La date de complétion est hors limites (entre 1900 et 2100)');
     if (data.dueAt && outOfBoundariesDate(data.dueAt)) return toast.error("La date d'échéance est hors limites (entre 1900 et 2100)");


### PR DESCRIPTION
TODO: les champs `status` et `completedAt` sont heureusement non chiffrés, une migration SQL sur les actions existantes devra être effectuée pour retirer tous les `completedAt` des actions `TODO`