### PR TITLE
feat: possibilité d'organiser les champs d'observation en groupes

### DIFF
--- a/api/src/controllers/custom-field.js
+++ b/api/src/controllers/custom-field.js
@@ -6,7 +6,7 @@ const { catchErrors } = require("../errors");
 const { TerritoryObservation, Organisation, Person, Consultation, MedicalFile, sequelize } = require("../db/sequelize");
 const { capture } = require("../sentry");
 const validateUser = require("../middleware/validateUser");
-const { looseUuidRegex, customFieldSchema } = require("../utils");
+const { looseUuidRegex, customFieldSchema, customFieldGroupSchema } = require("../utils");
 const { serializeOrganisation } = require("../utils/data-serializer");
 
 router.post(
@@ -34,25 +34,11 @@ router.post(
     }
     try {
       z.object({
-        customFieldsObs: z.optional(z.array(customFieldSchema)),
+        customFieldsObs: z.optional(z.array(customFieldGroupSchema)),
         fieldsPersonsCustomizableOptions: z.optional(z.array(customFieldSchema)),
         customFieldsMedicalFile: z.optional(z.array(customFieldSchema)),
-        customFieldsPersons: z.optional(
-          z.array(
-            z.object({
-              name: z.string().min(1),
-              fields: z.array(customFieldSchema),
-            })
-          )
-        ),
-        consultations: z.optional(
-          z.array(
-            z.object({
-              name: z.string().min(1),
-              fields: z.array(customFieldSchema),
-            })
-          )
-        ),
+        customFieldsPersons: z.optional(z.array(customFieldGroupSchema)),
+        consultations: z.optional(z.array(customFieldGroupSchema)),
       }).parse(req.body.customFields);
     } catch (e) {
       const error = new Error(`Invalid request in customFields put in custom-field: ${e}`);

--- a/api/src/db/migrations/20240319134556-observations-custom-fields-group.js
+++ b/api/src/db/migrations/20240319134556-observations-custom-fields-group.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const { QueryTypes } = require("sequelize");
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (t) => {
+      const rows = await queryInterface.sequelize.query(
+        'SELECT _id, "customFieldsObs" FROM "mano"."Organisation" where "customFieldsObs" is not null',
+        {
+          type: QueryTypes.SELECT,
+          transaction: t,
+        }
+      );
+
+      for (const row of rows) {
+        const updatedCustomFieldsObs = [{ name: "Groupe par défaut", fields: row.customFieldsObs || [] }];
+
+        await queryInterface.sequelize.query(`UPDATE "mano"."Organisation" SET "customFieldsObs" = :updatedCustomFieldsObs WHERE _id = :_id`, {
+          type: QueryTypes.UPDATE,
+          replacements: { updatedCustomFieldsObs: JSON.stringify(updatedCustomFieldsObs), _id: row._id },
+          transaction: t,
+        });
+      }
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (t) => {
+      const rows = await queryInterface.sequelize.query('SELECT _id, "customFieldsObs" FROM "mano"."Organisation"', {
+        type: QueryTypes.SELECT,
+        transaction: t,
+      });
+
+      for (const row of rows) {
+        // Assuming there's only one object in the array after the up migration,
+        // and that object has the structure { name: "Groupe par défaut", fields: [...] }
+        const originalCustomFieldsObs = row.customFieldsObs[0]?.fields || [];
+
+        await queryInterface.sequelize.query(`UPDATE "mano"."Organisation" SET "customFieldsObs" = :originalCustomFieldsObs WHERE _id = :_id`, {
+          type: QueryTypes.UPDATE,
+          replacements: { originalCustomFieldsObs: JSON.stringify(originalCustomFieldsObs), _id: row._id },
+          transaction: t,
+        });
+      }
+    });
+  },
+};

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -52,6 +52,13 @@ const customFieldSchema = z
   })
   .strict();
 
+const customFieldGroupSchema = z
+  .object({
+    name: z.string().min(1),
+    fields: z.array(customFieldSchema),
+  })
+  .strict();
+
 function sanitizeAll(text) {
   return sanitizeHtml(text || "", { allowedTags: [], allowedAttributes: {} });
 }
@@ -68,5 +75,6 @@ module.exports = {
   dateRegex,
   isoDateRegex,
   customFieldSchema,
+  customFieldGroupSchema,
   sanitizeAll,
 };

--- a/api/src/utils/data-serializer.js
+++ b/api/src/utils/data-serializer.js
@@ -47,7 +47,11 @@ function serializeOrganisation(organisation) {
     /* custom fields consultations */
     consultations: organisation.consultations,
     /* custom fields observations */
-    customFieldsObs: organisation.customFieldsObs,
+    groupedCustomFieldsObs: organisation.customFieldsObs,
+    // This works as usual (before the migration) because the default group is the only one
+    // Autrement dit, si quelqu'un n'a pas mis à jour l'app ou le dashboard, il a tous ses champs
+    // d'observation en vrac comme avant.
+    customFieldsObs: (organisation.customFieldsObs || []).reduce((flattenedFields, group) => [...flattenedFields, ...group.fields], []),
     /* fixed fields persons */
     personFields: personFields,
     /* custom fields persons: fields with customizavble options only */

--- a/app/src/recoil/territoryObservations.js
+++ b/app/src/recoil/territoryObservations.js
@@ -15,8 +15,17 @@ export const customFieldsObsSelector = selector({
   key: 'customFieldsObsSelector',
   get: ({ get }) => {
     const organisation = get(organisationState);
-    if (Array.isArray(organisation.customFieldsObs)) return organisation.customFieldsObs;
+    if (Array.isArray(organisation.customFieldsObs) && organisation.customFieldsObs.length) return organisation.customFieldsObs;
     return defaultCustomFields;
+  },
+});
+
+export const groupedCustomFieldsObsSelector = selector({
+  key: 'groupedCustomFieldsObsSelector',
+  get: ({ get }) => {
+    const organisation = get(organisationState);
+    if (Array.isArray(organisation.groupedCustomFieldsObs) && organisation.groupedCustomFieldsObs.length) return organisation.groupedCustomFieldsObs;
+    return [{ name: 'Groupe par défaut', fields: defaultCustomFields }];
   },
 });
 

--- a/dashboard/src/components/SelectTeam.jsx
+++ b/dashboard/src/components/SelectTeam.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import SelectCustom from "./SelectCustom";
 
-const SelectTeam = ({ name, onChange = () => null, teamId = null, teams = null, style = null, inputId = "" }) => {
+const SelectTeam = ({ name, onChange = () => null, teamId = null, teams = null, style = null, inputId = "", ...rest }) => {
   useEffect(() => {
     if (teams?.length === 1 && !teamId) onChange(teams[0]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -21,6 +21,7 @@ const SelectTeam = ({ name, onChange = () => null, teamId = null, teams = null, 
         isClearable={false}
         inputId={inputId}
         classNamePrefix={inputId}
+        {...rest}
       />
     </div>
   );

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -22,7 +22,7 @@ export const customFieldsObsSelector = selector({
   key: "customFieldsObsSelector",
   get: ({ get }) => {
     const organisation = get(organisationState);
-    if (Array.isArray(organisation.customFieldsObs)) return organisation.customFieldsObs;
+    if (Array.isArray(organisation.customFieldsObs) && organisation.customFieldsObs.length) return organisation.customFieldsObs;
     return defaultCustomFields;
   },
 });
@@ -31,7 +31,7 @@ export const groupedCustomFieldsObsSelector = selector({
   key: "groupedCustomFieldsObsSelector",
   get: ({ get }) => {
     const organisation = get(organisationState);
-    if (Array.isArray(organisation.groupedCustomFieldsObs)) return organisation.groupedCustomFieldsObs;
+    if (Array.isArray(organisation.groupedCustomFieldsObs) && organisation.groupedCustomFieldsObs.length) return organisation.groupedCustomFieldsObs;
     return [{ name: "Groupe par défaut", fields: defaultCustomFields }];
   },
 });

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -27,6 +27,15 @@ export const customFieldsObsSelector = selector({
   },
 });
 
+export const groupedCustomFieldsObsSelector = selector({
+  key: "groupedCustomFieldsObsSelector",
+  get: ({ get }) => {
+    const organisation = get(organisationState);
+    if (Array.isArray(organisation.groupedCustomFieldsObs)) return organisation.groupedCustomFieldsObs;
+    return [{ name: "Groupe par défaut", fields: defaultCustomFields }];
+  },
+});
+
 export const defaultCustomFields = [
   {
     name: "personsMale",
@@ -92,7 +101,7 @@ const compulsoryEncryptedFields = ["territory", "user", "team", "observedAt"];
 export const prepareObsForEncryption =
   (customFields) =>
   (obs, { checkRequiredFields = true } = {}) => {
-    if (!!checkRequiredFields) {
+    if (checkRequiredFields) {
       try {
         if (!looseUuidRegex.test(obs.territory)) {
           throw new Error("Observation is missing territory");

--- a/dashboard/src/scenes/organisation/ObservationsSettings.jsx
+++ b/dashboard/src/scenes/organisation/ObservationsSettings.jsx
@@ -262,13 +262,15 @@ const ObservationCustomField = ({ item: customField, groupTitle: typeName }) => 
     setIsEditingField(false);
     const updatedObservations = replaceOldChoiceByNewChoice(observations, oldChoice, newChoice, field);
 
+    const newCustomFieldsObsFlat = newCustomFieldsObs.reduce((acc, type) => [...acc, ...type.fields], []);
+
     const response = await API.post({
       path: "/custom-field",
       body: {
         customFields: {
           customFieldsObs: newCustomFieldsObs,
         },
-        observations: await Promise.all(updatedObservations.map(prepareObsForEncryption(newCustomFieldsObs)).map(encryptItem)),
+        observations: await Promise.all(updatedObservations.map(prepareObsForEncryption(newCustomFieldsObsFlat)).map(encryptItem)),
       },
     });
     if (response.ok) {

--- a/dashboard/src/scenes/organisation/ObservationsSettings.jsx
+++ b/dashboard/src/scenes/organisation/ObservationsSettings.jsx
@@ -1,11 +1,16 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { useDataLoader } from "../../components/DataLoader";
 import { organisationState } from "../../recoil/auth";
 import API, { encryptItem } from "../../services/api";
 import { toast } from "react-toastify";
 import DragAndDropSettings from "./DragAndDropSettings";
-import { customFieldsObsSelector, prepareObsForEncryption, territoryObservationsState } from "../../recoil/territoryObservations";
+import {
+  customFieldsObsSelector,
+  groupedCustomFieldsObsSelector,
+  prepareObsForEncryption,
+  territoryObservationsState,
+} from "../../recoil/territoryObservations";
 import CustomFieldSetting from "../../components/CustomFieldSetting";
 import { EditCustomField } from "../../components/TableCustomFields";
 
@@ -19,39 +24,95 @@ const sanitizeFields = (field) => {
 
 const ObservationsSettings = () => {
   const [organisation, setOrganisation] = useRecoilState(organisationState);
-  const customFieldsObs = useRecoilValue(customFieldsObsSelector);
-  const dataFormatted = useMemo(() => {
-    return [
-      {
-        groupTitle: "Observations de territoire",
-        items: customFieldsObs,
-      },
-    ];
-  }, [customFieldsObs]);
+  const flatCustomFieldsObs = useRecoilValue(customFieldsObsSelector);
+  const groupedCustomFieldsObs = useRecoilValue(groupedCustomFieldsObsSelector);
+
+  const dataFormatted = groupedCustomFieldsObs.map((group) => ({
+    groupTitle: group.name,
+    items: group.fields,
+  }));
 
   const { refresh } = useDataLoader();
 
-  const onDragAndDrop = useCallback(
-    async ([{ items }]) => {
-      const reorderedCustomFields = items.map((fieldName, index) => customFieldsObs.find((field) => field.name === fieldName)).map(sanitizeFields);
+  const onAddGroup = async (name) => {
+    const res = await API.put({
+      path: `/organisation/${organisation._id}`,
+      body: { customFieldsObs: [...groupedCustomFieldsObs, { name, fields: [] }] },
+    });
+    if (res.ok) {
+      toast.success("Groupe ajouté", { autoclose: 2000 });
+      setOrganisation(res.data);
+    }
+    refresh();
+  };
 
-      try {
-        const response = await API.put({
-          path: `/organisation/${organisation._id}`,
-          body: { customFieldsObs: reorderedCustomFields },
-        });
-        if (response.ok) {
-          toast.success("Mise à jour !");
-          setOrganisation(response.data);
-          refresh();
-        }
-      } catch (orgUpdateError) {
-        console.log("error in updating organisation", orgUpdateError);
-        toast.error(orgUpdateError.message);
+  const onGroupTitleChange = async (oldName, newName) => {
+    if (!newName) {
+      toast.error("Vous devez saisir un nom pour le groupe de champs personnalisés");
+      return;
+    }
+    const newCustomFieldsObs = groupedCustomFieldsObs.map((type) => {
+      if (type.name !== oldName) return type;
+      return {
+        ...type,
+        name: newName,
+      };
+    });
+
+    const oldOrganisation = organisation;
+    setOrganisation({ ...organisation, customFieldsObs: newCustomFieldsObs }); // optimistic UI
+    const response = await API.put({
+      path: `/organisation/${organisation._id}`,
+      body: { customFieldsObs: newCustomFieldsObs },
+    });
+    if (response.ok) {
+      refresh();
+      setOrganisation(response.data);
+      toast.success("Groupe mise à jour. Veuillez notifier vos équipes pour qu'elles rechargent leur app ou leur dashboard");
+    } else {
+      setOrganisation(oldOrganisation);
+      toast.error("Une erreur inattendue est survenue, l'équipe technique a été prévenue. Désolé !");
+    }
+  };
+
+  const onDeleteGroup = async (name) => {
+    const newCustomFieldsObs = groupedCustomFieldsObs.filter((type) => type.name !== name);
+
+    const oldOrganisation = organisation;
+    setOrganisation({ ...organisation, customFieldsObs: newCustomFieldsObs }); // optimistic UI
+
+    const response = await API.put({
+      path: `/organisation/${organisation._id}`,
+      body: { customFieldsObs: newCustomFieldsObs },
+    });
+    if (response.ok) {
+      toast.success("Groupe d'observations de territoire supprimé", { autoclose: 2000 });
+      setOrganisation(response.data);
+      refresh();
+    } else {
+      setOrganisation(oldOrganisation);
+    }
+  };
+
+  const onDragAndDrop = useCallback(
+    async (newCustomFieldsObs) => {
+      newCustomFieldsObs = newCustomFieldsObs.map((group) => ({
+        name: group.groupTitle,
+        fields: group.items.map((customFieldName) => flatCustomFieldsObs.find((f) => f.name === customFieldName)),
+      }));
+      const res = await API.put({
+        path: `/organisation/${organisation._id}`,
+        body: { customFieldsObs: newCustomFieldsObs },
+      });
+      if (res.ok) {
+        setOrganisation(res.data);
+        refresh();
       }
     },
-    [customFieldsObs, organisation._id, refresh, setOrganisation]
+    [flatCustomFieldsObs, organisation._id, refresh, setOrganisation]
   );
+
+  console.log(flatCustomFieldsObs, groupedCustomFieldsObs);
 
   return (
     <DragAndDropSettings
@@ -61,22 +122,37 @@ const ObservationsSettings = () => {
       ItemComponent={ObservationCustomField}
       NewItemComponent={AddField}
       onDragAndDrop={onDragAndDrop}
+      addButtonCaption="Ajouter un groupe de champs personnalisés"
+      onAddGroup={onAddGroup}
+      onGroupTitleChange={onGroupTitleChange}
+      onDeleteGroup={onDeleteGroup}
     />
   );
 };
 
-const AddField = () => {
-  const customFieldsObs = useRecoilValue(customFieldsObsSelector);
-
+const AddField = ({ groupTitle: typeName }) => {
+  const groupedCustomFieldsObs = useRecoilValue(groupedCustomFieldsObsSelector);
+  const flatCustomFieldsObs = useRecoilValue(customFieldsObsSelector);
   const [organisation, setOrganisation] = useRecoilState(organisationState);
   const [isAddingField, setIsAddingField] = useState(false);
   const { refresh } = useDataLoader();
 
   const onAddField = async (newField) => {
     try {
+      if (flatCustomFieldsObs.map((e) => e.label).includes(newField.label)) {
+        return toast.error(`Ce nom de champ existe déjà dans un autre groupe`);
+      }
+
+      const newCustomFieldsObs = groupedCustomFieldsObs.map((type) => {
+        if (type.name !== typeName) return type;
+        return {
+          ...type,
+          fields: [...type.fields, newField].map(sanitizeFields),
+        };
+      });
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
-        body: { customFieldsObs: [...customFieldsObs, newField] },
+        body: { customFieldsObs: newCustomFieldsObs },
       });
       if (response.ok) {
         toast.success("Mise à jour !");
@@ -134,20 +210,27 @@ const replaceOldChoiceByNewChoice = (data, oldChoice, newChoice, field) => {
     .filter(Boolean);
 };
 
-const ObservationCustomField = ({ item: customField }) => {
+const ObservationCustomField = ({ item: customField, groupTitle: typeName }) => {
   const [isSelected, setIsSelected] = useState(false);
   const [isEditingField, setIsEditingField] = useState(false);
   const [organisation, setOrganisation] = useRecoilState(organisationState);
   const observations = useRecoilValue(territoryObservationsState);
-  const customFieldsObs = useRecoilValue(customFieldsObsSelector);
+  const groupedCustomFieldsObs = useRecoilValue(groupedCustomFieldsObsSelector);
 
   const { refresh } = useDataLoader();
 
   const onSaveField = async (editedField) => {
     try {
+      const newCustomFieldsObs = groupedCustomFieldsObs.map((type) => {
+        if (type.name !== typeName) return type;
+        return {
+          ...type,
+          fields: type.fields.map((field) => (field.name !== editedField.name ? field : editedField)).map(sanitizeFields),
+        };
+      });
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
-        body: { customFieldsObs: customFieldsObs.map((field) => (field.name !== editedField.name ? field : editedField)) },
+        body: { customFieldsObs: newCustomFieldsObs },
       });
       if (response.ok) {
         toast.success("Mise à jour !");
@@ -161,15 +244,21 @@ const ObservationCustomField = ({ item: customField }) => {
     setIsEditingField(false);
   };
 
-  const onEditChoice = async ({ oldChoice, newChoice, field, fields }) => {
-    const updatedFields = customFieldsObs.map((_field) =>
-      _field.name !== field.name
-        ? _field
-        : {
-            ..._field,
-            options: _field.options.map((option) => (option === oldChoice ? newChoice : option)),
-          }
-    );
+  const onEditChoice = async ({ oldChoice, newChoice, field }) => {
+    const newCustomFieldsObs = groupedCustomFieldsObs.map((type) => {
+      if (type.name !== typeName) return type;
+      return {
+        ...type,
+        fields: type.fields.map((_field) =>
+          _field.name !== field.name
+            ? _field
+            : {
+                ..._field,
+                options: _field.options.map((option) => (option === oldChoice ? newChoice : option)),
+              }
+        ),
+      };
+    });
     setIsEditingField(false);
     const updatedObservations = replaceOldChoiceByNewChoice(observations, oldChoice, newChoice, field);
 
@@ -177,9 +266,9 @@ const ObservationCustomField = ({ item: customField }) => {
       path: "/custom-field",
       body: {
         customFields: {
-          customFieldsObs: updatedFields,
+          customFieldsObs: newCustomFieldsObs,
         },
-        observations: await Promise.all(updatedObservations.map(prepareObsForEncryption(updatedFields)).map(encryptItem)),
+        observations: await Promise.all(updatedObservations.map(prepareObsForEncryption(newCustomFieldsObs)).map(encryptItem)),
       },
     });
     if (response.ok) {
@@ -191,9 +280,16 @@ const ObservationCustomField = ({ item: customField }) => {
 
   const onDeleteField = async () => {
     try {
+      const newCustomFieldsObs = groupedCustomFieldsObs.map((type) => {
+        if (type.name !== typeName) return type;
+        return {
+          ...type,
+          fields: type.fields.filter((field) => field.name !== customField.name),
+        };
+      });
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
-        body: { customFieldsObs: customFieldsObs.filter((field) => field.name !== customField.name) },
+        body: { customFieldsObs: newCustomFieldsObs },
       });
       if (response.ok) {
         toast.success("Mise à jour !");

--- a/dashboard/src/scenes/organisation/ServicesSettings.jsx
+++ b/dashboard/src/scenes/organisation/ServicesSettings.jsx
@@ -140,6 +140,7 @@ const AddService = ({ groupTitle, services, onDragAndDrop }) => {
     if (!newService) return toast.error("Vous devez saisir un nom pour le service");
     if (flattenedServices.includes(newService)) {
       const existingGroupTitle = groupedServices.find(({ services }) => services.includes(newService)).groupTitle;
+      // eslint-disable-next-line no-irregular-whitespace
       return toast.error(`Ce service existe déjà : ${existingGroupTitle} > ${newService}`);
     }
     const newGroupedServices = groupedServices.map((group) => {

--- a/dashboard/src/types/organisation.ts
+++ b/dashboard/src/types/organisation.ts
@@ -33,6 +33,7 @@ export interface OrganisationInstance {
   groupedServices?: GroupedServices[];
 
   customFieldsObs: CustomField[];
+  groupedCustomFieldsObs?: CustomFieldsGroup[];
   personFields: PredefinedField[];
   customFieldsPersons: CustomFieldsGroup[];
   customFieldsMedicalFile: CustomField[];

--- a/e2e/custom-fields_toggle-by-team.spec.ts
+++ b/e2e/custom-fields_toggle-by-team.spec.ts
@@ -236,10 +236,7 @@ test("Create custom fields filtered by team", async ({ page }) => {
 
   await page.locator(`data-test-id=${testObsTerritoryField}`).click();
 
-  await page
-    .locator('div[role="document"]:has-text("Modifier l\'observation×Nombre de personnes non connues hommes rencontréesNombre ")')
-    .getByRole("button", { name: "Close" })
-    .click();
+  await page.getByText("AnnulerLoading...Sauvegarder").getByRole("button", { name: "Annuler" }).click();
 
   /*
   Test the restrictions on the fields
@@ -274,8 +271,5 @@ test("Create custom fields filtered by team", async ({ page }) => {
 
   await expect(page.locator(`data-test-id=${testObsTerritoryField}`)).toBeHidden();
 
-  await page
-    .locator('div[role="document"]:has-text("Modifier l\'observation×Nombre de personnes non connues hommes rencontréesNombre ")')
-    .getByRole("button", { name: "Close" })
-    .click();
+  await page.getByText("AnnulerLoading...Sauvegarder").getByRole("button", { name: "Annuler" }).click();
 });

--- a/e2e/global_encryption-check-all-data-type.spec.ts
+++ b/e2e/global_encryption-check-all-data-type.spec.ts
@@ -161,7 +161,7 @@ test("test", async ({ page }) => {
   await page.getByRole("link", { name: "Territoires" }).click();
   await page.getByText(testTerritoire).click();
   await page.getByText("Un commentaire").click();
-  await page.getByRole("button", { name: "Close" }).click();
+  await page.getByRole("button", { name: "Annuler" }).click();
   await page.getByRole("link", { name: "Agenda" }).click();
   await page.getByText(monAction).click();
   await page.getByRole("button", { name: "Commentaires (1)" }).click();

--- a/e2e/restricted-role_V2.spec.ts
+++ b/e2e/restricted-role_V2.spec.ts
@@ -212,7 +212,6 @@ test("test", async ({ page }) => {
   await page.getByRole("button", { name: "Sauvegarder" }).click();
   await page.getByText("Création réussie !").click();
   await page.getByText("Nombre de personnes non connues hommes rencontrées: 3Nombre de personnes non con").click();
-  await page.getByRole("dialog").click();
   await page.getByRole("dialog").getByLabel("Commentaire", { exact: true }).fill("modifier une observation");
   await page.getByLabel("Nombre de personnes non connues hommes rencontrées").click();
   await page.getByLabel("Nombre de personnes non connues hommes rencontrées").fill("2");


### PR DESCRIPTION
Statut : pour l'instant on peut créer et gérer les groupes (+ c'est rétrocompatible). On a aussi un affichage des groupes (s'il y en a plus qu'un) dans le web et mobile.

Il s'agit d'un premier gros morceau pour les rencontres dans les observations de territoire.

https://www.notion.so/mano-sesan/En-tant-que-maraudeur-j-ai-besoin-de-pouvoir-saisir-mes-rencontres-depuis-mes-observations-de-terri-0725eb07a79e473d9477715ffd9de54d?pvs=4

~~Prochaine étape : afficher comme dans la maquette les groupes de champ sur mobile et dashboard.~~
~~Prochaine étape : afficher comme dans la maquette les groupes de champ sur mobile~~

D'un point de vue implémentation c'est plutôt simple et ça permet d'être compatible sans la course de l'ordre API, dashboard, etc. vu que les champs sont envoyés toujours à plat et que l'orga en groupe est en bonus. J'ai fait comme ça en lisant nos précédentes PR c'était plus compliqué.