### PR TITLE
fix: on n'inclus pas les passages qui n'ont pas de date dans les rapports (reste à savoir pourquoi ils n'en ont pas)

### DIFF
--- a/dashboard/src/scenes/report/view.jsx
+++ b/dashboard/src/scenes/report/view.jsx
@@ -169,6 +169,9 @@ const itemsForReportsSelector = selectorFamily({
       for (const passage of allPassages) {
         if (!filterItemByTeam(passage, "team")) continue;
         const date = passage.date;
+        // Je ne sais pas pourquoi, mais il semblerait que certains passages n'aient pas de date.
+        // cf: https://www.notion.so/mano-sesan/Bug-affichage-des-passage-6f539d3706c04b27b1290a39763d91e5
+        if (!date) continue;
         const { isoStartDate, isoEndDate } = selectedTeamsObjectWithOwnPeriod[passage.team] ?? defaultIsoDates;
         if (date < isoStartDate) continue;
         if (date >= isoEndDate) continue;


### PR DESCRIPTION
Voir: https://www.notion.so/mano-sesan/Bug-affichage-des-passage-6f539d3706c04b27b1290a39763d91e5