### PR TITLE
fix: gère le cas où la date de départ est la même qu'une date de l'historique

### DIFF
--- a/dashboard/__tests__/evolutives-stats-for-persons.test.ts
+++ b/dashboard/__tests__/evolutives-stats-for-persons.test.ts
@@ -71,7 +71,7 @@ describe("Stats evolutives", () => {
           gender: "Homme",
           history: [
             {
-              date: dayjs("2024-01-01").toDate(),
+              date: dayjs("2024-01-02").toDate(),
               data: {
                 gender: {
                   oldValue: "Homme",
@@ -238,6 +238,46 @@ describe("Stats evolutives", () => {
     expect(computed.valueStart).toBe("Non renseigné");
     expect(computed.countStart).toBe(1);
     expect(computed.valueEnd).toBe("Femme");
+    expect(computed.countEnd).toBe(1);
+    expect(dayjs(computed.startDateConsolidated).format("YYYY-MM-DD")).toBe("2024-01-01");
+    expect(dayjs(computed.endDateConsolidated).format("YYYY-MM-DD")).toBe("2024-04-01");
+  });
+
+  test("If a history change is the same a period start date, we ignore it", () => {
+    const computed = computeEvolutiveStatsForPersons({
+      startDate: "2024-01-01T00:00:00.000Z",
+      endDate: "2024-04-01T00:00:00.000Z",
+      evolutiveStatsIndicatorsBase: mockedEvolutiveStatsIndicatorsBase,
+      evolutiveStatsIndicators: [
+        {
+          fieldName: "resources",
+          fromValue: "Non renseigné",
+          toValue: "RSA",
+          type: "enum",
+        },
+      ],
+      persons: [
+        {
+          ...personBase,
+          resources: ["RSA"],
+          history: [
+            {
+              date: dayjs("2024-12-31").toDate(),
+              data: {
+                resources: {
+                  oldValue: "",
+                  newValue: ["RSA"],
+                },
+              },
+              user: "XXX",
+            },
+          ],
+        },
+      ],
+    });
+    expect(computed.valueStart).toBe("Non renseigné");
+    expect(computed.countStart).toBe(1);
+    expect(computed.valueEnd).toBe("RSA");
     expect(computed.countEnd).toBe(1);
     expect(dayjs(computed.startDateConsolidated).format("YYYY-MM-DD")).toBe("2024-01-01");
     expect(dayjs(computed.endDateConsolidated).format("YYYY-MM-DD")).toBe("2024-04-01");

--- a/dashboard/src/recoil/evolutiveStats.ts
+++ b/dashboard/src/recoil/evolutiveStats.ts
@@ -107,7 +107,12 @@ function getPersonSnapshotAtDate({
   const reversedHistory = [...history].reverse();
   for (const historyItem of reversedHistory) {
     const historyDate = dayjsInstance(historyItem.date).format("YYYYMMDD");
-    if (historyDate < snapshotDate) return snapshot;
+    // history is: before the date
+    // snapshot is: after the date
+    // what should we do for a history change on the same day as the snapshot ?
+    // 2 options: we keep the snapshot, or we keep the history change
+    // we keep the snapshot because it's more coherent with L258-L259
+    if (historyDate <= snapshotDate) return snapshot; // if snapshot's day is history's day, we return the snapshot
     for (const historyChangeField of Object.keys(historyItem.data)) {
       const oldValue = getValueByField(historyChangeField, fieldsMap, historyItem.data[historyChangeField].oldValue);
       const historyNewValue = getValueByField(historyChangeField, fieldsMap, historyItem.data[historyChangeField].newValue);


### PR DESCRIPTION
avant: 
![image](https://github.com/mano-sesan/mano/assets/31724752/9a31c996-eb8b-46c7-baa8-91574e0cc101)

il faut constater que le 23/09/2022, certaines personnes sont Non renseignées ET RSA par exemple - pas possible

après: 
![image](https://github.com/mano-sesan/mano/assets/31724752/4b4f268f-e06c-4eb2-b9a4-20bd91e92eb9)


