### PR TITLE
fix: le nombre de personnes suivi ayant reçu une action est basé sur le nombre de personnes suivies

### DIFF
--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -190,7 +190,7 @@ export const itemsGroupedByPersonSelector = selector({
       personsObject[action.person].interactions.push(action.dueAt);
       personsObject[action.person].interactions.push(action.createdAt);
       personsObject[action.person].interactions.push(action.completedAt);
-      if (!!action.group) {
+      if (action.group) {
         const group = personsObject[action.person].group;
         if (!group) continue;
         for (const person of group.persons) {
@@ -214,7 +214,7 @@ export const itemsGroupedByPersonSelector = selector({
       personsObject[comment.person].comments = personsObject[comment.person].comments || [];
       personsObject[comment.person].comments.push({ ...comment, type: "person", date: comment.date || comment.createdAt });
       personsObject[comment.person].interactions.push(comment.date || comment.createdAt);
-      if (!!comment.group) {
+      if (comment.group) {
         const group = personsObject[comment.person].group;
         if (!group) continue;
         for (const person of group.persons) {
@@ -541,7 +541,7 @@ export const populatedPassagesSelector = selector({
         if (!!passage.person && !allPersonsAsObject[passage.person]) return null;
         return {
           ...passage,
-          type: !!passage.person ? "Non-anonyme" : "Anonyme",
+          type: passage.person ? "Non-anonyme" : "Anonyme",
           gender: !passage.person ? null : allPersonsAsObject[passage.person].gender || "Non renseigné",
         };
       })

--- a/dashboard/src/scenes/stats/ActionsStats.jsx
+++ b/dashboard/src/scenes/stats/ActionsStats.jsx
@@ -25,7 +25,7 @@ const ActionsStats = ({
   filterBase,
   filterPersons,
   setFilterPersons,
-  personsWithActions,
+  personsUpdatedWithActions,
 }) => {
   const [actionsModalOpened, setActionsModalOpened] = useState(false);
   const [groupSlice, setGroupSlice] = useState(null);
@@ -61,9 +61,10 @@ const ActionsStats = ({
 
   const filterTitle = useMemo(() => {
     if (!filterPersons.length) return `Filtrer par personnes suivies :`;
-    if (personsWithActions === 1) return `Filtrer par personnes suivies (${personsWithActions} personne concernée par le filtre actuel) :`;
-    return `Filtrer par personnes suivies (${personsWithActions} personnes concernées par le filtre actuel) :`;
-  }, [filterPersons, personsWithActions]);
+    if (personsUpdatedWithActions === 1)
+      return `Filtrer par personnes suivies (${personsUpdatedWithActions} personne associée aux équipes en charges séléctionnées concernée par le filtre actuel) :`;
+    return `Filtrer par personnes suivies (${personsUpdatedWithActions} personnes associées aux équipes en charges séléctionnées concernées par le filtre actuel) :`;
+  }, [filterPersons, personsUpdatedWithActions]);
 
   return (
     <>

--- a/dashboard/src/scenes/stats/GeneralStats.jsx
+++ b/dashboard/src/scenes/stats/GeneralStats.jsx
@@ -8,7 +8,7 @@ const GeneralStats = ({
   rencontres,
   actions,
   // numberOfActionsPerPersonConcernedByActions,
-  personsWithActions,
+  personsUpdatedWithActions,
   filterBase,
   filterPersons,
   setFilterPersons,
@@ -46,9 +46,9 @@ const GeneralStats = ({
           help={`Moyenne d'actions créées par "personne suivie" <b>pour lesquelles au moins une action a été créée</b> dans la période définie.\n\nSi aucune période n'est définie, on considère la totalité des actions par rapport à la totalité des personnes.`}
         /> */}
         <Block
-          data={personsWithActions}
+          data={personsUpdatedWithActions}
           title="Nombre de personnes suivies concernées par au moins une action"
-          help={`Nombre de personnes suivies <b>pour lesquelles au moins une action a été créée</b> dans la période définie.\n\nSi aucune période n'est définie, on considère la totalité des actions par rapport à la totalité des personnes.`}
+          help={`Nombre de personnes suivies par les équipes sélectionnées <b>pour lesquelles au moins une action a été créée</b> dans la période définie.\n\nSi aucune période n'est définie, on considère la totalité des actions par rapport à la totalité des personnes.`}
         />
       </div>
     </>

--- a/dashboard/src/scenes/stats/index.jsx
+++ b/dashboard/src/scenes/stats/index.jsx
@@ -107,7 +107,8 @@ const itemsForStatsSelector = selectorFamily({
 
       const personsCreated = [];
       const personsUpdated = [];
-      const personsWithActions = {};
+      // Les personnes suivies ayant des actions
+      const personsUpdatedWithActions = {};
       const actionsFilteredByPersons = {};
       const consultationsFilteredByPersons = [];
       const personsWithConsultations = {};
@@ -153,7 +154,9 @@ const itemsForStatsSelector = selectorFamily({
           if (!filterItemByTeam(action, "teams")) continue;
           if (noPeriodSelected) {
             actionsFilteredByPersons[action._id] = action;
-            personsWithActions[person._id] = person;
+            // On veut seulement les personnes considérées comme suivies
+            // Pour ne pas avoir plus de personnes suivies concernées par les actions que de personnes suivies
+            if (personsUpdated[person._id]) personsUpdatedWithActions[person._id] = person;
             continue;
           }
           const date = action.completedAt || action.dueAt;
@@ -172,7 +175,8 @@ const itemsForStatsSelector = selectorFamily({
             if (date >= isoEndDate) continue;
           }
           actionsFilteredByPersons[action._id] = action;
-          personsWithActions[person._id] = person;
+          // Voir ci-dessus (pourquoi on limite aux personnes suivies)
+          if (personsUpdated[person._id]) personsUpdatedWithActions[person._id] = person;
         }
         for (const consultation of person.consultations || []) {
           if (!filterItemByTeam(consultation, "teams")) continue;
@@ -240,7 +244,7 @@ const itemsForStatsSelector = selectorFamily({
       return {
         personsCreated: Object.values(personsCreated),
         personsUpdated: Object.values(personsUpdated),
-        personsWithActions: Object.keys(personsWithActions).length,
+        personsUpdatedWithActions: Object.keys(personsUpdatedWithActions).length,
         actionsFilteredByPersons: Object.values(actionsFilteredByPersons),
         personsWithConsultations: Object.keys(personsWithConsultations).length,
         consultationsFilteredByPersons,
@@ -357,7 +361,7 @@ const Stats = () => {
   const {
     personsCreated,
     personsUpdated,
-    personsWithActions,
+    personsUpdatedWithActions,
     actionsFilteredByPersons,
     personsWithConsultations,
     consultationsFilteredByPersons,
@@ -600,7 +604,7 @@ const Stats = () => {
             rencontres={rencontresFilteredByPersons}
             actions={actionsWithDetailedGroupAndCategories}
             // numberOfActionsPerPersonConcernedByActions={numberOfActionsPerPersonConcernedByActions}
-            personsWithActions={personsWithActions}
+            personsUpdatedWithActions={personsUpdatedWithActions}
             // filter by persons
             filterBase={filterPersonsWithAllFields()}
             filterPersons={filterPersons}
@@ -624,7 +628,7 @@ const Stats = () => {
             actionsCategories={actionsCategories}
             filterableActionsCategories={filterableActionsCategories}
             // filter by persons
-            personsWithActions={personsWithActions}
+            personsUpdatedWithActions={personsUpdatedWithActions}
             filterBase={filterPersonsWithAllFields()}
             filterPersons={filterPersons}
             setFilterPersons={setFilterPersons}


### PR DESCRIPTION
Voir: https://www.notion.so/mano-sesan/Bug-stat-fil-active-action-69ddbf65b1cd438da6fe859ad336d8a2
Et des discussions sur slack dont : https://manodiscussion.slack.com/archives/C02U0F8CN0Y/p1712914917835769

PS : désolé pour les modifs sur le premier fichier je peux les virer j'ai l'impression que c'est mon éditeur qui a fait ça. comme ça m'arrange bien, je laisse mais je peux vierer