### PR TITLE
fix: correction d'un test automatisé

### DIFF
--- a/e2e/consultations_create-consultation-from-agenda.spec.ts
+++ b/e2e/consultations_create-consultation-from-agenda.spec.ts
@@ -33,7 +33,7 @@ test("test", async ({ page }) => {
   await page.getByRole("button", { name: "Modifier" }).click();
   await page.getByLabel("Nom (facultatif)").fill("Avec un nom");
   await page.getByRole("button", { name: "Sauvegarder" }).click();
-  await page.getByText("Consultation Médicale").click();
+  await page.getByRole("cell", { name: "Avec un nom Médicale" }).click();
   await page.getByRole("button", { name: "Historique" }).click();
   await page.locator('[data-test-id="Nom\\: \\"\\" ➔ \\"Avec un nom\\""]').click();
 });


### PR DESCRIPTION
Je ne comprends même pas comment ça pouvait marcher ... Dans la saisie d'écran ci-dessous, la consultation n'a pas du tout comme texte "Consultation Médicale"... J'imagine qu'il devait y avoir quelque chose qui se passait "rapidement". En tout cas, je pense que c'est mieux comme ça

<img width="1003" alt="Capture d’écran 2024-04-16 à 11 04 03" src="https://github.com/mano-sesan/mano/assets/1575946/c69b3737-141e-4614-8f4c-73284f14b92b">
