### PR TITLE
fix: les observations de territoire dans le dashboard affichaient la date de création au lieu de la date d'observation

### DIFF
--- a/dashboard/src/scenes/territory-observations/list.jsx
+++ b/dashboard/src/scenes/territory-observations/list.jsx
@@ -66,7 +66,7 @@ const List = ({ territory = {} }) => {
             onSortBy: setSortBy,
             sortOrder,
             sortBy,
-            render: (obs) => formatDateWithFullMonth(obs.createdAt || ""),
+            render: (obs) => formatDateWithFullMonth(obs.observedAt || obs.createdAt),
           },
           {
             title: "Créée par",


### PR DESCRIPTION
Voir: [date de création au lieu de la date d'observation](https://www.notion.so/mano-sesan/Bug-dates-observation-99df4b337cfa4744adda78bc7f68dc00?pvs=4)