### PR TITLE
feat: ajout des territoires dans l'encart rencontres de la fiche d'une personne et amélioration de l'affichage des rencontres et passages à cet endroit

### DIFF
--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -337,7 +337,9 @@ export const itemsGroupedByPersonSelector = selector({
       }
     }
 
-    // Cette zone sert à récupérer les territoires liés au rencontres (par rebonds)
+    // Cette zone sert à récupérer les territoires liés au rencontres (par rebonds via l'observation)
+    // On pourra se débarasser de ça quand on aura des territoires directement liés aux observations,
+    // autrement dit, en créant un objet enrichi d'observations avec leur territoires.
     const rencontresObject = {};
     const rencontresByObservations = {};
     for (const rencontre of rencontres) {

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -14,6 +14,7 @@ import { medicalFileState } from "./medicalFiles";
 import { treatmentsState } from "./treatments";
 import { rencontresState } from "./rencontres";
 import { groupsState } from "./groups";
+import { territoriesState } from "./territory";
 
 const tomorrow = dayjsInstance().add(1, "day").format("YYYY-MM-DD");
 
@@ -143,6 +144,8 @@ export const itemsGroupedByPersonSelector = selector({
     const places = get(placesObjectSelector);
     const rencontres = get(rencontresState);
     const groups = get(groupsState);
+    const observations = get(territoryObservationsState);
+    const territories = get(territoriesState);
 
     for (const group of groups) {
       for (const person of group.persons) {
@@ -333,10 +336,49 @@ export const itemsGroupedByPersonSelector = selector({
         });
       }
     }
+
+    // Cette zone sert à récupérer les territoires liés au rencontres (par rebonds)
+    const rencontresObject = {};
+    const rencontresByObservations = {};
     for (const rencontre of rencontres) {
       if (!personsObject[rencontre.person]) continue;
+      rencontresObject[rencontre._id] = rencontre;
+      if (!rencontre.observation) continue;
+      if (!rencontresByObservations[rencontre.observation]) rencontresByObservations[rencontre.observation] = [];
+      rencontresByObservations[rencontre.observation].push(rencontre._id);
+    }
+
+    const observationsForRencontresObject = {};
+    const observationsByTerritories = {};
+    for (const observation of observations) {
+      if (!rencontresByObservations[observation._id]) continue;
+      observationsForRencontresObject[observation._id] = { territory: observation.territory }; // Plus tard on pourra enrichir, pour l'instant on n'a besoin que de ça.
+      if (!observationsByTerritories[observation.territory]) observationsByTerritories[observation.territory] = [];
+      observationsByTerritories[observation.territory].push(observation._id);
+    }
+
+    const territoriesForObservationsForRencontresObject = {};
+    for (const territory of territories) {
+      if (!observationsByTerritories[territory._id]) continue;
+      territoriesForObservationsForRencontresObject[territory._id] = { name: territory.name };
+    }
+    // Fin de la zone nommée au dessus
+
+    for (const rencontre of Object.values(rencontresObject)) {
+      if (!personsObject[rencontre.person]) continue;
       personsObject[rencontre.person].rencontres = personsObject[rencontre.person].rencontres || [];
-      personsObject[rencontre.person].rencontres.push(rencontre);
+      if (rencontre.observation) {
+        const observationObject = observationsForRencontresObject[rencontre.observation];
+        const territoryObject = territoriesForObservationsForRencontresObject[observationObject.territory];
+        personsObject[rencontre.person].rencontres.push({
+          ...rencontre,
+          observationObject,
+          territoryObject,
+        });
+      } else {
+        personsObject[rencontre.person].rencontres.push(rencontre);
+      }
+
       personsObject[rencontre.person].interactions.push(rencontre.date || rencontre.createdAt);
       if (rencontre.comment) {
         personsObject[rencontre.person].comments = personsObject[rencontre.person].comments || [];

--- a/dashboard/src/scenes/person/components/PassagesRencontres.jsx
+++ b/dashboard/src/scenes/person/components/PassagesRencontres.jsx
@@ -60,7 +60,7 @@ export default function PassagesRencontres({ person }) {
 
   return (
     <div className="tw-relative">
-      <div className="tw-sticky tw-top-0 tw-z-10 tw-mb-3 tw-flex tw-bg-white tw-p-3 tw-text-main tw-shadow-sm">
+      <div className="tw-sticky tw-top-0 tw-z-10 tw-flex tw-bg-white tw-p-2 tw-text-main">
         <div className="tw-flex tw-flex-1">
           {organisation.passagesEnabled && (
             <button
@@ -213,15 +213,23 @@ function PassagesTable({ personPassages, users }) {
               }}
             >
               <td>
-                <div>{formatDateTimeWithNameOfDay(passage.date || passage.createdAt)}</div>
-                <div style={{ overflowWrap: "anywhere" }}>
-                  {(passage.comment || "").split("\n").map((e, i) => (
-                    <p key={e + i}>{e}</p>
-                  ))}
+                <div className="tw-flex tw-text-black50 tw-capitalize tw-mb-1">
+                  <div>{formatDateTimeWithNameOfDay(passage.date || passage.createdAt)}</div>
                 </div>
-                <div className="small">Créé par {users.find((e) => e._id === passage.user)?.name}</div>
-                <div className="tw-max-w-fit">
-                  <TagTeam teamId={passage.team} />
+                {passage.comment ? (
+                  <div style={{ overflowWrap: "anywhere" }}>
+                    {(passage.comment || "").split("\n").map((e, i) => (
+                      <p className="tw-m-0 tw-p-0" key={e + i}>
+                        {e}
+                      </p>
+                    ))}
+                  </div>
+                ) : null}
+                <div className="tw-flex tw-mt-1">
+                  <div className="tw-grow tw-text-black50">Créé par {users.find((e) => e._id === passage.user)?.name}</div>
+                  <div className="tw-max-w-fit">
+                    <TagTeam teamId={passage.team} />
+                  </div>
                 </div>
               </td>
             </tr>
@@ -246,15 +254,30 @@ function RencontresTable({ personRencontres, users }) {
               }}
             >
               <td>
-                <div>{formatDateTimeWithNameOfDay(rencontre.date || rencontre.createdAt)}</div>
-                <div style={{ overflowWrap: "anywhere" }}>
-                  {(rencontre.comment || "").split("\n").map((e, i) => (
-                    <p key={e + i}>{e}</p>
-                  ))}
+                <div className="tw-flex tw-text-black50 tw-capitalize tw-mb-1">
+                  <div className="tw-grow">{formatDateTimeWithNameOfDay(rencontre.date || rencontre.createdAt)}</div>
+                  {rencontre.territoryObject ? (
+                    <div>
+                      <div className="tw-truncate	 tw-max-w-24	tw-bg-black tw-py-0.5 tw-px-1 tw-rounded tw-text-white tw-text-xs">
+                        {rencontre.territoryObject.name}
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
-                <div className="small">Créé par {users.find((e) => e._id === rencontre.user)?.name}</div>
-                <div className="tw-max-w-fit">
-                  <TagTeam teamId={rencontre.team} />
+                {rencontre.comment ? (
+                  <div style={{ overflowWrap: "anywhere" }}>
+                    {(rencontre.comment || "").split("\n").map((e, i) => (
+                      <p className="tw-m-0 tw-p-0" key={e + i}>
+                        {e}
+                      </p>
+                    ))}
+                  </div>
+                ) : null}
+                <div className="tw-flex tw-mt-1">
+                  <div className="tw-grow tw-text-black50">Créé par {users.find((e) => e._id === rencontre.user)?.name}</div>
+                  <div className="tw-max-w-fit">
+                    <TagTeam teamId={rencontre.team} />
+                  </div>
                 </div>
               </td>
             </tr>

--- a/dashboard/src/scenes/person/components/PassagesRencontres.jsx
+++ b/dashboard/src/scenes/person/components/PassagesRencontres.jsx
@@ -213,7 +213,7 @@ function PassagesTable({ personPassages, users }) {
               }}
             >
               <td>
-                <div className="tw-flex tw-text-black50 tw-capitalize tw-mb-1">
+                <div className="tw-flex tw-text-black50 tw-capitalize tw-mb-1 tw-text-xs tw-items-center">
                   <div>{formatDateTimeWithNameOfDay(passage.date || passage.createdAt)}</div>
                 </div>
                 {passage.comment ? (
@@ -225,7 +225,7 @@ function PassagesTable({ personPassages, users }) {
                     ))}
                   </div>
                 ) : null}
-                <div className="tw-flex tw-mt-1">
+                <div className="tw-flex tw-mt-1 tw-text-xs tw-items-center">
                   <div className="tw-grow tw-text-black50">Créé par {users.find((e) => e._id === passage.user)?.name}</div>
                   <div className="tw-max-w-fit">
                     <TagTeam teamId={passage.team} />
@@ -254,7 +254,7 @@ function RencontresTable({ personRencontres, users }) {
               }}
             >
               <td>
-                <div className="tw-flex tw-text-black50 tw-capitalize tw-mb-1">
+                <div className="tw-flex tw-text-black50 tw-capitalize tw-mb-1 tw-text-xs tw-items-center">
                   <div className="tw-grow">{formatDateTimeWithNameOfDay(rencontre.date || rencontre.createdAt)}</div>
                   {rencontre.territoryObject ? (
                     <div>
@@ -273,7 +273,7 @@ function RencontresTable({ personRencontres, users }) {
                     ))}
                   </div>
                 ) : null}
-                <div className="tw-flex tw-mt-1">
+                <div className="tw-flex tw-mt-1 tw-text-xs tw-items-center">
                   <div className="tw-grow tw-text-black50">Créé par {users.find((e) => e._id === rencontre.user)?.name}</div>
                   <div className="tw-max-w-fit">
                     <TagTeam teamId={rencontre.team} />


### PR DESCRIPTION
Désolé j'ai fait deux trucs en même temps c'était un peu difficile de séparer car il fallait faire évoluer l'affichage pour permettre d'afficher le territoire lié à la rencontre

<img width="878" alt="Capture d’écran 2024-04-18 à 16 17 05" src="https://github.com/mano-sesan/mano/assets/1575946/cbc97679-63e1-407c-8a27-5e4ef2d3bf44">
