### PR TITLE
fix: affiche l'historique sans les doublons le cas échéant

### DIFF
--- a/dashboard/src/recoil/evolutiveStats.ts
+++ b/dashboard/src/recoil/evolutiveStats.ts
@@ -79,7 +79,7 @@ function getValueByField(fieldName: CustomOrPredefinedField["name"], fieldsMap: 
       return value;
     }
     if (value == null || value === "") {
-      return ["Non renseigné"];
+      return [];
     }
     return [value];
   }


### PR DESCRIPTION
je pense qu;'on a d'autres problèmes avec l'historique, peut-être qu'un clean sera nécessaire, après résolution

pourquoi je dis d'autres problèmes ?
- on a cette erreur sur sentry: https://mano-20.sentry.io/issues/5144987024/?environment=dashboard&project=4506672157229056&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=0
- ça concerne Alexia (org test), et effectivement y'a une incohérence d'historique sur les Ressources, difficile à comprendre

bon en attendant, je cherche à reproduire l'historique qui pète, mais je ne vois pas