### PR TITLE
fix: oriente vers les champs non valides (ouvre la tab concernée) lorsqu'on tente d'enregistrer mais qu'ils sont non valides

### DIFF
--- a/dashboard/src/components/ActionModal.jsx
+++ b/dashboard/src/components/ActionModal.jsx
@@ -484,6 +484,7 @@ function ActionContent({ onClose, action, personId = null, personIds = null, isM
                           name="dueAt"
                           defaultValue={data.dueAt ?? new Date()}
                           onChange={handleChange}
+                          onInvalid={() => setActiveTab("Informations")}
                         />
                         <div>
                           <input
@@ -566,6 +567,7 @@ function ActionContent({ onClose, action, personId = null, personIds = null, isM
                         name="completedAt"
                         defaultValue={data.completedAt ?? new Date()}
                         onChange={handleChange}
+                        onInvalid={() => setActiveTab("Informations")}
                       />
                     </div>
                   </div>

--- a/dashboard/src/components/ConsultationModal.jsx
+++ b/dashboard/src/components/ConsultationModal.jsx
@@ -419,6 +419,7 @@ function ConsultationContent({ personId, consultation, date, onClose }) {
                       name="dueAt"
                       defaultValue={data.dueAt ?? new Date()}
                       onChange={handleChange}
+                      onInvalid={() => setActiveTab("Informations")}
                     />
                   ) : (
                     <CustomFieldDisplay type="date-with-time" value={data.dueAt} />
@@ -439,6 +440,7 @@ function ConsultationContent({ personId, consultation, date, onClose }) {
                       name="completedAt"
                       defaultValue={data.completedAt ?? new Date()}
                       onChange={handleChange}
+                      onInvalid={() => setActiveTab("Informations")}
                     />
                   ) : (
                     <CustomFieldDisplay type="date-with-time" value={data.completedAt} />

--- a/dashboard/src/components/DatePicker.tsx
+++ b/dashboard/src/components/DatePicker.tsx
@@ -1,3 +1,4 @@
+import type { FormEvent } from "react";
 import { dateForInputDate, dateFromInputDate, LEFT_BOUNDARY_DATE, RIGHT_BOUNDARY_DATE } from "../services/date";
 
 interface DatePickerProps {
@@ -6,9 +7,19 @@ interface DatePickerProps {
   id: string;
   withTime?: boolean;
   name?: string;
+  required?: boolean;
+  onInvalid?: (e: FormEvent<HTMLInputElement>) => void;
 }
 
-export default function DatePicker({ onChange, defaultValue, id, withTime = false, name = "" }: DatePickerProps): JSX.Element {
+export default function DatePicker({
+  onChange,
+  defaultValue,
+  id,
+  withTime = false,
+  name = "",
+  required = false,
+  onInvalid = () => null,
+}: DatePickerProps): JSX.Element {
   return (
     <input
       id={id}
@@ -20,6 +31,8 @@ export default function DatePicker({ onChange, defaultValue, id, withTime = fals
       onChange={(e) => {
         onChange({ target: { name: e.target.name, value: dateFromInputDate(e.target.value) } });
       }}
+      required={required}
+      onInvalid={onInvalid}
       min={dateForInputDate(LEFT_BOUNDARY_DATE, withTime)}
       max={dateForInputDate(RIGHT_BOUNDARY_DATE, withTime)}
     />

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -80,6 +80,7 @@ const OutOfActiveList = ({ person }) => {
       );
       toast.success(person.name + " est hors de la file active");
     }
+    setOpen(false);
   };
 
   return (
@@ -95,13 +96,7 @@ const OutOfActiveList = ({ person }) => {
           Sortie de file active de {person.name}
         </ModalHeader>
         <ModalBody>
-          <Formik
-            initialValues={{ ...person, outOfActiveListDate: Date.now(), outOfActiveListReasons: [] }}
-            onSubmit={async (body) => {
-              await setOutOfActiveList(body);
-              setOpen(false);
-            }}
-          >
+          <Formik initialValues={{ ...person, outOfActiveListDate: Date.now(), outOfActiveListReasons: [] }} onSubmit={setOutOfActiveList}>
             {({ values, handleChange, handleSubmit, isSubmitting }) => (
               <React.Fragment>
                 <Row>

--- a/dashboard/src/scenes/person/components/EditModal.jsx
+++ b/dashboard/src/scenes/person/components/EditModal.jsx
@@ -65,16 +65,32 @@ export default function EditModal({ person, selectedPanel, onClose, isMedicalFil
           enableReinitialize
           initialValues={person}
           onSubmit={async (body) => {
-            if (!body.name?.trim()?.length) return toast.error("Une personne doit avoir un nom");
+            if (!body.name?.trim()?.length) {
+              setOpenPanels(["main"]);
+              return toast.error("Une personne doit avoir un nom");
+            }
             const existingPerson = persons.find((p) => p.name === body.name && p._id !== person._id);
-            if (existingPerson) return toast.error("Une personne existe déjà à ce nom");
+            if (existingPerson) {
+              setOpenPanels(["main"]);
+              return toast.error("Une personne existe déjà à ce nom");
+            }
             if (!body.followedSince) body.followedSince = person.createdAt;
-            if (!body.assignedTeams?.length) return toast.error("Une personne doit être suivie par au moins une équipe");
-            if (outOfBoundariesDate(body.followedSince)) return toast.error("La date de suivi est hors limites (entre 1900 et 2100)");
-            if (body.birthdate && outOfBoundariesDate(body.birthdate))
+            if (!body.assignedTeams?.length) {
+              setOpenPanels(["main"]);
+              return toast.error("Une personne doit être suivie par au moins une équipe");
+            }
+            if (outOfBoundariesDate(body.followedSince)) {
+              setOpenPanels(["main"]);
+              return toast.error("La date de suivi est hors limites (entre 1900 et 2100)");
+            }
+            if (body.birthdate && outOfBoundariesDate(body.birthdate)) {
+              setOpenPanels(["main"]);
               return toast.error("La date de naissance est hors limites (entre 1900 et 2100)");
-            if (body.wanderingAt && outOfBoundariesDate(body.wanderingAt))
+            }
+            if (body.wanderingAt && outOfBoundariesDate(body.wanderingAt)) {
+              setOpenPanels(["main"]);
               return toast.error("La date temps passé en rue est hors limites (entre 1900 et 2100)");
+            }
 
             body.entityKey = person.entityKey;
 

--- a/dashboard/src/scenes/person/components/TreatmentModal.jsx
+++ b/dashboard/src/scenes/person/components/TreatmentModal.jsx
@@ -136,6 +136,7 @@ function TreatmentContent({ onClose, treatment, personId }) {
   async function handleSubmit({ newData = {}, closeOnSubmit = false } = {}) {
     const body = { ...data, ...newData };
     if (!body.name) {
+      setActiveTab("Informations");
       toast.error("Le nom est obligatoire");
       return false;
     }
@@ -144,10 +145,12 @@ function TreatmentContent({ onClose, treatment, personId }) {
       return false;
     }
     if (outOfBoundariesDate(body.startDate)) {
+      setActiveTab("Informations");
       toast.error("La date de début de traitement est hors limites (entre 1900 et 2100)");
       return false;
     }
     if (body.endDate && outOfBoundariesDate(body.endDate)) {
+      setActiveTab("Informations");
       toast.error("La date de fin de traitement est hors limites (entre 1900 et 2100)");
       return false;
     }
@@ -273,7 +276,16 @@ function TreatmentContent({ onClose, treatment, personId }) {
                   Nom
                 </label>
                 {isEditing ? (
-                  <input className="tailwindui" placeholder="Amoxicilline" name="name" id="medicine-name" value={data.name} onChange={handleChange} />
+                  <input
+                    className="tailwindui"
+                    required
+                    onInvalid={() => setActiveTab("Informations")}
+                    placeholder="Amoxicilline"
+                    name="name"
+                    id="medicine-name"
+                    value={data.name}
+                    onChange={handleChange}
+                  />
                 ) : (
                   <CustomFieldDisplay value={data.name} type="text" />
                 )}
@@ -327,7 +339,14 @@ function TreatmentContent({ onClose, treatment, personId }) {
                   Date de début
                 </label>
                 {isEditing ? (
-                  <DatePicker id="startDate" name="startDate" defaultValue={data.startDate} onChange={handleChange} />
+                  <DatePicker
+                    id="startDate"
+                    name="startDate"
+                    defaultValue={data.startDate}
+                    onChange={handleChange}
+                    required
+                    onInvalid={() => setActiveTab("Informations")}
+                  />
                 ) : (
                   <CustomFieldDisplay value={data.startDate} type="date" />
                 )}
@@ -337,7 +356,13 @@ function TreatmentContent({ onClose, treatment, personId }) {
                   Date de fin
                 </label>
                 {isEditing ? (
-                  <DatePicker id="endDate" name="endDate" defaultValue={data.endDate} onChange={handleChange} />
+                  <DatePicker
+                    id="endDate"
+                    name="endDate"
+                    defaultValue={data.endDate}
+                    onChange={handleChange}
+                    onInvalid={() => setActiveTab("Informations")}
+                  />
                 ) : (
                   <CustomFieldDisplay value={data.endDate} type="date" />
                 )}

--- a/e2e/persons_person-full-test-migrated-from-jest.spec.ts
+++ b/e2e/persons_person-full-test-migrated-from-jest.spec.ts
@@ -150,7 +150,11 @@ test("test", async ({ page }) => {
   await page.getByLabel("Date de fin").fill("2000-11-11");
   await page.getByLabel("Date de début").fill("2009-11-11");
   await page.getByRole("button", { name: "Sauvegarder" }).click();
-  await page.getByText("Le nom est obligatoire").first().click();
+  const validationMessage = await page.getByPlaceholder("Amoxicilline").evaluate((element) => {
+    const input = element as HTMLInputElement;
+    return input.validationMessage;
+  });
+  expect(validationMessage).toContain("Please fill in this field.");
   await page.getByPlaceholder("Amoxicilline").click();
   await page.getByPlaceholder("Amoxicilline").fill("hdeyygdeygde");
   await page.getByRole("button", { name: "Sauvegarder" }).click();

--- a/e2e/persons_person-full-test-migrated-from-jest.spec.ts
+++ b/e2e/persons_person-full-test-migrated-from-jest.spec.ts
@@ -154,7 +154,8 @@ test("test", async ({ page }) => {
     const input = element as HTMLInputElement;
     return input.validationMessage;
   });
-  expect(validationMessage).toContain("Please fill in this field.");
+  expect(validationMessage).toContain("Please fill out this field.");
+
   await page.getByPlaceholder("Amoxicilline").click();
   await page.getByPlaceholder("Amoxicilline").fill("hdeyygdeygde");
   await page.getByRole("button", { name: "Sauvegarder" }).click();


### PR DESCRIPTION
https://www.notion.so/mano-sesan/Bug-Traitements-bf6bcb99936a4f79a38324488aecfb3e?pvs=4

le comportement qui frustre, c'est dire qu'il y a une erreur quelque part mais non ne sait pas forcément où
j'ai touché
- aux éléments qui ont plusieurs tabs (ActionModal, ConsultationModal et TraitementModal)
- à la Personne Suivie, qui a des `panels`
- à la modale de sortie de file active, qui se ferme même si la date rentrée est non valide