### PR TITLE
fix: rétablit la possibilité de forcer le vidage du cache depuis le code grâce à la clé `mano_last_refresh`, qui avait été retiré dpuis la migration vers `idb-keyval`

### DIFF
--- a/dashboard/jest.setup.js
+++ b/dashboard/jest.setup.js
@@ -1,0 +1,19 @@
+// jest.setup.js
+global.window = {}; // Mock window object
+global.window.localStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn(),
+};
+
+global.window.sessionStorage = {
+  clear: jest.fn(),
+};
+
+global.window.indexedDB = {
+  deleteDatabase: jest.fn(() => ({
+    onerror: jest.fn(),
+    onblocked: jest.fn(),
+    onsuccess: jest.fn(),
+  })),
+};

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -110,7 +110,8 @@
       "**/__tests__/**/*?(*.)+(spec|test).ts"
     ],
     "setupFiles": [
-      "fake-indexeddb/auto"
+      "fake-indexeddb/auto",
+      "./jest.setup.js"
     ]
   },
   "browserslist": {

--- a/dashboard/src/scenes/auth/signin.jsx
+++ b/dashboard/src/scenes/auth/signin.jsx
@@ -64,7 +64,8 @@ const SignIn = () => {
       if (ok && token && user) {
         setAuthViaCookie(true);
         const { organisation } = user;
-        if (organisation._id !== window.localStorage.getItem("mano-organisationId")) {
+        const storedOrganisationId = window.localStorage.getItem("mano-organisationId");
+        if (storedOrganisationId && storedOrganisationId !== organisation._id) {
           await resetCache();
         }
         window.localStorage.setItem("mano-organisationId", organisation._id);
@@ -107,7 +108,8 @@ const SignIn = () => {
       const { user, token, ok } = authViaCookie ? await API.get({ path: "/user/signin-token" }) : await API.post({ path: "/user/signin", body });
       if (!ok) return setIsSubmitting(false);
       const { organisation } = user;
-      if (organisation._id !== window.localStorage.getItem("mano-organisationId")) {
+      const storedOrganisationId = window.localStorage.getItem("mano-organisationId");
+      if (storedOrganisationId && organisation._id !== storedOrganisationId) {
         await resetCache();
       }
       setOrganisation(organisation);


### PR DESCRIPTION
ça m'a pris 2 bonnes heures mine de rien !