### PR TITLE
fix: lorsque la clé de chiffrement change, ne plus charger de donnée tant que l'utilisateur n'a pas rechargé sa page

### DIFF
--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -90,7 +90,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   const setTotal = useSetRecoilState(totalState);
 
   const setUser = useSetRecoilState(userState);
-  const setOrganisation = useSetRecoilState(organisationState);
+  const [organisation, setOrganisation] = useRecoilState(organisationState);
   const { migrateData } = useDataMigrator();
 
   const [persons, setPersons] = useRecoilState(personsState);
@@ -154,6 +154,9 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     const latestOrganisation = userResponse.user.organisation;
     const latestUser = userResponse.user;
     const organisationId = latestOrganisation._id;
+    if (organisation.encryptionLastUpdateAt !== latestOrganisation.encryptionLastUpdateAt) {
+      return toast.error("La clé de chiffrement a changé ou a été régénérée. Veuillez vous déconnecter et vous reconnecter avec la nouvelle clé.");
+    }
     setOrganisation(latestOrganisation);
     setUser(latestUser);
     if (isStartingInitialLoad) {


### PR DESCRIPTION
fixera probablement https://mano-20.sentry.io/issues/5054090483/activity/?project=4506672157229056&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=10

j'ai réussi à reproduire localement le fait d'avoir une `ERROR DECRYPTING ITEM` lorsqu'un autre utilisateur change la clé, et que je veux rafraichir mes données - vu que j'ai la mauvaise clé, j'ai une erreur de déchiffrement