### PR TITLE
fix: ne recharge pas la page lors d'une erreur de rafraichissement

### DIFF
--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -489,10 +489,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     // this can result in data corruption, we need to reset the loader
     setLastLoad(0);
     await clearCache();
-    toast.error(errorMessage(error || "Désolé, une erreur est survenue lors du chargement de vos données, veuillez réessayer"), {
-      onClose: () => window.location.replace("/auth"),
-      autoClose: 5000,
-    });
+    toast.error(errorMessage(error || "Désolé, une erreur est survenue lors du chargement de vos données, veuillez réessayer"));
     return false;
   }
 


### PR DESCRIPTION
certaines personnes se plaignent que lorsqu'il y a des problèmes de chargement, ils perdent le commentaire qu'il étaient en train d'écrire, etc.

je me dis que PEUT-ÊTRE que si ne recharge pas la page automatiquement, ça ira mieux ?