### PR TITLE
chore: pas besoin de refresh dans le rechiffrement

### DIFF
--- a/dashboard/src/components/EncryptionKey.jsx
+++ b/dashboard/src/components/EncryptionKey.jsx
@@ -28,14 +28,13 @@ const EncryptionKey = ({ isMain }) => {
   const [encryptingStatus, setEncryptingStatus] = useState("");
   const [encryptingProgress, setEncryptingProgress] = useState(0);
   const [encryptionDone, setEncryptionDone] = useState(false);
-  const { isLoading, refresh } = useDataLoader();
+  const { isLoading } = useDataLoader();
 
   useEffect(() => {
     if (open) {
-      refresh();
+      // do seomething on the next PR
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, encryptionKey]);
+  }, [open]);
 
   if (!["admin"].includes(user.role)) return null;
 


### PR DESCRIPTION
on a pas besoin de ce refreshn puisque de toutes façons on retélécharge tout depuis le serveur une fois qu'on a renseigné la nouvelle clé

PS: c'est une PR préalable à la PR #265