### PR TITLE
fix: contrôle du cache depuis le backend

### DIFF
--- a/api/src/controllers/utils.js
+++ b/api/src/controllers/utils.js
@@ -12,10 +12,11 @@ router.get("/check-auth", passport.authenticate("user", { session: false, failWi
 router.get("/now", passport.authenticate("user", { session: false, failWithError: true }), async (req, res) => {
   const data = Date.now();
   const currentCacheValidationKey = req.query.currentCacheValidationKey;
-  if (currentCacheValidationKey !== "mano_last_refresh_2024_06_11") {
+  if (currentCacheValidationKey !== "mano_last_refresh_2024_06_12") {
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/205
     // The HTTP 205 Reset Content response status tells the client to reset the document view,
     // so for example to clear the content of a form, reset a canvas state, or to refresh the UI.
+    // BUT: on the front-end, we don't read the error with status 205, so we send back 200
     res.status(200).send({ ok: false, error: "Mano a besoin de se rafraichir et de recharger toutes vos données, désolé pour la gène occasionnée" });
     return;
   }

--- a/api/src/controllers/utils.js
+++ b/api/src/controllers/utils.js
@@ -16,7 +16,7 @@ router.get("/now", passport.authenticate("user", { session: false, failWithError
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/205
     // The HTTP 205 Reset Content response status tells the client to reset the document view,
     // so for example to clear the content of a form, reset a canvas state, or to refresh the UI.
-    res.status(205).send({ ok: false, error: "Mano a besoin de se rafraichir et de recharger toutes vos données, désolé pour la gène occasionnée" });
+    res.status(200).send({ ok: false, error: "Mano a besoin de se rafraichir et de recharger toutes vos données, désolé pour la gène occasionnée" });
     return;
   }
   res.status(200).send({ ok: true, data });

--- a/api/src/controllers/utils.js
+++ b/api/src/controllers/utils.js
@@ -11,6 +11,14 @@ router.get("/check-auth", passport.authenticate("user", { session: false, failWi
 
 router.get("/now", passport.authenticate("user", { session: false, failWithError: true }), async (req, res) => {
   const data = Date.now();
+  const currentCacheValidationKey = req.query.currentCacheValidationKey;
+  if (currentCacheValidationKey !== "mano_last_refresh_2024_06_11") {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/205
+    // The HTTP 205 Reset Content response status tells the client to reset the document view,
+    // so for example to clear the content of a form, reset a canvas state, or to refresh the UI.
+    res.status(205).send({ ok: false, error: "Mano a besoin de se rafraichir et de recharger toutes vos données, désolé pour la gène occasionnée" });
+    return;
+  }
   res.status(200).send({ ok: true, data });
 });
 

--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -187,7 +187,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     // Get date from server just after getting all the stats
     // We'll set the `lastLoadValue` to this date after all the data is downloaded
     const [serverDateError, serverDateResponse] = await tryFetchExpectOk(() => {
-      return API.get({ path: "/now" });
+      return API.get({ path: "/now", query: { currentCacheValidationKey: dashboardCurrentCacheKey } });
     });
     if (serverDateError) return resetLoaderOnError(serverDateError);
     const serverDate = serverDateResponse.data;

--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -186,9 +186,11 @@ export function useDataLoader(options = { refreshOnMount: false }) {
 
     // Get date from server just after getting all the stats
     // We'll set the `lastLoadValue` to this date after all the data is downloaded
-    const [serverDateError, serverDateResponse] = await tryFetchExpectOk(() => {
+    const [serverDateError, serverDateResponse] = await tryFetch(() => {
       return API.get({ path: "/now", query: { currentCacheValidationKey: dashboardCurrentCacheKey } });
-    });
+    }, true);
+    console.log("serverDateResponse", serverDateResponse);
+    console.log("serverDateError", serverDateError);
     if (serverDateError) return resetLoaderOnError(serverDateError);
     const serverDate = serverDateResponse.data;
 

--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -188,9 +188,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     // We'll set the `lastLoadValue` to this date after all the data is downloaded
     const [serverDateError, serverDateResponse] = await tryFetch(() => {
       return API.get({ path: "/now", query: { currentCacheValidationKey: dashboardCurrentCacheKey } });
-    }, true);
-    console.log("serverDateResponse", serverDateResponse);
-    console.log("serverDateError", serverDateError);
+    });
     if (serverDateError) return resetLoaderOnError(serverDateError);
     const serverDate = serverDateResponse.data;
 

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -179,10 +179,9 @@ export async function tryFetchBlob<T extends Blob>(callback: FetchCallback<T>): 
   }
 }
 
-export async function tryFetch<T extends ApiResponse>(callback: FetchCallback<T>, debug?: boolean): Promise<[Error | undefined, T | undefined]> {
+export async function tryFetch<T extends ApiResponse>(callback: FetchCallback<T>): Promise<[Error | undefined, T | undefined]> {
   try {
     const result = await callback();
-    if (debug) console.log(result);
     if (result && !result.ok) return [new Error(result.error), result];
     return [undefined, result];
   } catch (error) {

--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -179,9 +179,10 @@ export async function tryFetchBlob<T extends Blob>(callback: FetchCallback<T>): 
   }
 }
 
-export async function tryFetch<T extends ApiResponse>(callback: FetchCallback<T>): Promise<[Error | undefined, T | undefined]> {
+export async function tryFetch<T extends ApiResponse>(callback: FetchCallback<T>, debug?: boolean): Promise<[Error | undefined, T | undefined]> {
   try {
     const result = await callback();
+    if (debug) console.log(result);
     if (result && !result.ok) return [new Error(result.error), result];
     return [undefined, result];
   } catch (error) {

--- a/dashboard/src/services/dataManagement.ts
+++ b/dashboard/src/services/dataManagement.ts
@@ -1,7 +1,7 @@
 import { type UseStore, set, get, createStore, keys, delMany, clear } from "idb-keyval";
 import { capture } from "./sentry";
 
-export const dashboardCurrentCacheKey = "mano_last_refresh_2024_05_06";
+export const dashboardCurrentCacheKey = "mano_last_refresh_2024_06_11";
 const legacyStoreName = "mano_last_refresh_2022_01_11";
 const legacyManoDB = "mano-dashboard";
 const manoDB = "mano";


### PR DESCRIPTION
comportement pour ceux qui n'auront pas la dernière version du dashboard: ça va vider le cache et forcer le reload avec un joli message d'erreur

pour ceux qui auront la version actuelle: ça va encoyer un message sur sentry à cause du `tryFetchExpectOk`, que j'ai remplacé par `tryFetch` pour la suite