### PR TITLE
chore: reset cache à l'ancienne (ce qui nous permettra de voir les gens qui ont toujours le problème après ça)

### DIFF
--- a/dashboard/src/services/dataManagement.ts
+++ b/dashboard/src/services/dataManagement.ts
@@ -1,7 +1,7 @@
 import { type UseStore, set, get, createStore, keys, delMany, clear } from "idb-keyval";
 import { capture } from "./sentry";
 
-export const dashboardCurrentCacheKey = "mano_last_refresh_2024_05_06";
+export const dashboardCurrentCacheKey = "mano_last_refresh_2024_06_11";
 const legacyStoreName = "mano_last_refresh_2022_01_11";
 const legacyManoDB = "mano-dashboard";
 const manoDB = "mano";


### PR DESCRIPTION
En attendant de faire un truc qui vient du back (et d'ailleurs je me demande si on en a tant besoin maintenant qu'on peut voir dans quelle release sont les gens directement, que ce soit dans sentry ou même dans le code grâce à VERSION, et que donc on peut complètement jouer avec ça) je pense qu'il faut refresh le cache pour pouvoir déteter quels sont les vrais problèmes encore en cours avec les éléments indéchiffrable pour les restaurer ?
Ça te va ?