### PR TITLE
chore: on ignore les erreur d'annulation manuelle de requête par l'utilisateur MANO-ESPACE-22

### DIFF
--- a/dashboard/src/app.jsx
+++ b/dashboard/src/app.jsx
@@ -83,6 +83,12 @@ if (ENV === "production") {
       // Since other browsers don't have this problem, we don't care about it,
       // it may be a false positive.
       "AbortError: The operation was aborted",
+      // Sur safari, on a des erreur de type "TypeError: cancelled" qui seraient liées
+      // au bouton "X" (ou refresh) pressé pendant un fetch. Il semblerait que la meilleure
+      // approche soit de les ignorer.
+      // Cf: https://stackoverflow.com/a/60860369/978690
+      "TypeError: cancelled",
+      "TypeError: annulé",
     ],
   });
 }


### PR DESCRIPTION
Voir https://stackoverflow.com/questions/55738408/javascript-typeerror-cancelled-error-when-calling-fetch-on-ios