### PR TITLE
fix: redirection vers auth en ignorant l'erreur dans tous les cas même sur la page auth, la seule exception est quand on fait api.getToken MANO-ESPACE-KT

### DIFF
--- a/dashboard/src/services/api.ts
+++ b/dashboard/src/services/api.ts
@@ -53,7 +53,7 @@ class Api {
   }
 
   protected needAuthRedirection(response: Response) {
-    return response.status === 401 && window?.location?.pathname !== "/auth";
+    return response.status === 401;
   }
 
   protected fetchParams(): RequestInit {


### PR DESCRIPTION
Et résout par la même occasion MANO-ESPACE-KT