### PR TITLE
feat: sortie de file active par équipe, première étape

### DIFF
--- a/dashboard/src/components/DatePicker.tsx
+++ b/dashboard/src/components/DatePicker.tsx
@@ -9,6 +9,7 @@ interface DatePickerProps {
   name?: string;
   required?: boolean;
   onInvalid?: (e: FormEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
 }
 
 export default function DatePicker({
@@ -19,6 +20,7 @@ export default function DatePicker({
   name = "",
   required = false,
   onInvalid = () => null,
+  disabled = false,
 }: DatePickerProps): JSX.Element {
   return (
     <input
@@ -28,6 +30,7 @@ export default function DatePicker({
       className="form-control"
       type={withTime ? "datetime-local" : "date"}
       defaultValue={dateForInputDate(defaultValue, withTime)}
+      disabled={disabled}
       onChange={(e) => {
         onChange({ target: { name: e.target.name, value: dateFromInputDate(e.target.value) } });
       }}

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -182,7 +182,7 @@ const OutOfActiveList = ({ person }) => {
               </ModalBody>
               <ModalFooter>
                 <ButtonCustom title="Annuler" type="button" onClick={() => setOpen(false)} color="secondary" />
-                <ButtonCustom title="Valider" type="submit" onClick={handleSubmit} color="primary" disabled={isSubmitting} />
+                <ButtonCustom title="Sauvegarder" type="submit" onClick={handleSubmit} color="primary" disabled={isSubmitting} />
               </ModalFooter>
             </React.Fragment>
           )}

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -78,7 +78,7 @@ const OutOfActiveList = ({ person }) => {
       }
     } else {
       const historyEntry = {
-        date: data.outOfActiveListDate,
+        date: new Date(),
         user: user._id,
         data: {
           assignedTeams: {
@@ -89,6 +89,12 @@ const OutOfActiveList = ({ person }) => {
             {
               team: data.team._id,
               reasons: data.outOfActiveListReasons,
+              date: data.outOfActiveListDate,
+            },
+            {
+              team: data.team._id,
+              reasons: data.outOfActiveListReasons,
+              date: data.outOfActiveListDate,
             },
           ],
         },

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -105,14 +105,14 @@ const OutOfActiveList = ({ person }) => {
           path: `/person/${person._id}`,
           body: await encryptPerson({
             ...person,
-            assignedTeams: person.assignedTeams.filter((team) => team !== data.team._id),
+            assignedTeams: person.assignedTeams.filter((team) => team !== data.team),
             history,
           }),
         })
       );
       if (!error) {
         await refresh();
-        toast.success(person.name + " est hors de la file active de " + data.team.name);
+        toast.success(person.name + " est hors de la file active de " + teams.find((t) => t._id === data.team)?.name);
       }
     }
 

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
-import { Col, FormGroup, Row, Modal, ModalBody, ModalHeader, Label } from "reactstrap";
 import { Formik } from "formik";
 import { toast } from "react-toastify";
 import { useRecoilValue } from "recoil";
-import { userState } from "../../recoil/auth";
+import { teamsState, userState } from "../../recoil/auth";
 import ButtonCustom from "../../components/ButtonCustom";
 import { fieldsPersonsCustomizableOptionsSelector, usePreparePersonForEncryption } from "../../recoil/persons";
 import API, { tryFetchExpectOk } from "../../services/api";
@@ -12,10 +11,12 @@ import SelectCustom from "../../components/SelectCustom";
 import DatePicker from "../../components/DatePicker";
 import { useDataLoader } from "../../components/DataLoader";
 import { cleanHistory } from "../../utils/person-history";
+import { ModalBody, ModalContainer, ModalFooter, ModalHeader } from "../../components/tailwind/Modal";
 
 const OutOfActiveList = ({ person }) => {
   const [open, setOpen] = useState(false);
   const { refresh } = useDataLoader();
+  const teams = useRecoilValue(teamsState);
 
   const { encryptPerson } = usePreparePersonForEncryption();
   const user = useRecoilValue(userState);
@@ -46,35 +47,75 @@ const OutOfActiveList = ({ person }) => {
     }
   };
 
-  const setOutOfActiveList = async (updatedPerson) => {
-    updatedPerson.outOfActiveList = true;
+  const setOutOfActiveList = async (data) => {
+    if (data.team === "all") {
+      if (data.outOfActiveListDate && outOfBoundariesDate(data.outOfActiveListDate))
+        return toast.error("La date de sortie de file active est hors limites (entre 1900 et 2100)");
+      const historyEntry = {
+        date: new Date(),
+        user: user._id,
+        data: {
+          outOfActiveList: { newValue: true },
+          outOfActiveListReasons: { newValue: data.outOfActiveListReasons },
+          outOfActiveListDate: { newValue: data.outOfActiveListDate },
+        },
+      };
 
-    if (updatedPerson.outOfActiveListDate && outOfBoundariesDate(updatedPerson.outOfActiveListDate))
-      return toast.error("La date de sortie de file active est hors limites (entre 1900 et 2100)");
+      const [error] = await tryFetchExpectOk(async () =>
+        API.put({
+          path: `/person/${person._id}`,
+          body: await encryptPerson({
+            ...person,
+            ...data,
+            outOfActiveList: true,
+            history: [...(cleanHistory(person.history) || []), historyEntry],
+          }),
+        })
+      );
+      if (!error) {
+        await refresh();
+        toast.success(person.name + " est hors de la file active");
+      }
+    } else {
+      const historyEntry = {
+        date: data.outOfActiveListDate,
+        user: user._id,
+        data: {
+          assignedTeams: {
+            oldValue: person.assignedTeams,
+            newValue: person.assignedTeams.filter((team) => team !== data.team._id),
+          },
+          outOfTeamsReasons: [
+            {
+              team: data.team._id,
+              reasons: data.outOfActiveListReasons,
+            },
+          ],
+        },
+      };
 
-    const historyEntry = {
-      date: new Date(),
-      user: user._id,
-      data: {
-        outOfActiveList: { newValue: true },
-        outOfActiveListReasons: { newValue: updatedPerson.outOfActiveListReasons },
-        outOfActiveListDate: { newValue: updatedPerson.outOfActiveListDate },
-      },
-    };
+      const history = [...(cleanHistory(person.history) || []), historyEntry].sort((a, b) => new Date(b.date) - new Date(a.date));
 
-    updatedPerson.history = [...(cleanHistory(person.history) || []), historyEntry];
-    const [error] = await tryFetchExpectOk(async () =>
-      API.put({
-        path: `/person/${person._id}`,
-        body: await encryptPerson(updatedPerson),
-      })
-    );
-    if (!error) {
-      await refresh();
-      toast.success(person.name + " est hors de la file active");
+      const [error] = await tryFetchExpectOk(async () =>
+        API.put({
+          path: `/person/${person._id}`,
+          body: await encryptPerson({
+            ...person,
+            assignedTeams: person.assignedTeams.filter((team) => team !== data.team._id),
+            history,
+          }),
+        })
+      );
+      if (!error) {
+        await refresh();
+        toast.success(person.name + " est hors de la file active de " + data.team.name);
+      }
     }
+
     setOpen(false);
   };
+
+  const teamsWithAll = [{ _id: "all", name: "Toute l'organisation" }, ...teams.filter((t) => person.assignedTeams.includes(t._id))];
 
   return (
     <>
@@ -84,63 +125,61 @@ const OutOfActiveList = ({ person }) => {
         onClick={() => (person.outOfActiveList ? reintegerInActiveList() : setOpen(true))}
         color={"warning"}
       />
-      <Modal isOpen={open} toggle={() => setOpen(false)} size="lg" backdrop="static">
-        <ModalHeader className="tw-break-all" toggle={() => setOpen(false)}>
-          Sortie de file active de {person.name}
-        </ModalHeader>
-        <ModalBody>
-          <Formik initialValues={{ ...person, outOfActiveListDate: Date.now(), outOfActiveListReasons: [] }} onSubmit={setOutOfActiveList}>
-            {({ values, handleChange, handleSubmit, isSubmitting }) => (
-              <React.Fragment>
-                <Row>
-                  <Col md={6}>
-                    <FormGroup>
-                      <label htmlFor="person-select-outOfActiveListReasons">
-                        Veuillez préciser le(s) motif(s) de sortie
-                        <SelectCustom
-                          options={fieldsPersonsCustomizableOptions
-                            .find((f) => f.name === "outOfActiveListReasons")
-                            .options?.map((_option) => ({ value: _option, label: _option }))}
-                          name="outOfActiveListReasons"
-                          onChange={(values) =>
-                            handleChange({ currentTarget: { value: values.map((v) => v.value), name: "outOfActiveListReasons" } })
-                          }
-                          isClearable={false}
-                          isMulti
-                          inputId="person-select-outOfActiveListReasons"
-                          classNamePrefix="person-select-outOfActiveListReasons"
-                          value={values.outOfActiveListReasons?.map((_option) => ({ value: _option, label: _option })) || []}
-                          placeholder={"Choisir..."}
-                          getOptionValue={(i) => i.value}
-                          getOptionLabel={(i) => i.label}
-                          styles={{ width: "800px" }}
-                          style={{ width: "800px" }}
-                        />
-                      </label>
-                    </FormGroup>
-                  </Col>
-                  <Col md={6}>
-                    <FormGroup>
-                      <Label htmlFor="person-birthdate">Date de sortie de file active</Label>
+      <ModalContainer open={open} size="full">
+        <ModalHeader title={`Sortie de file active de ${person.name}`} />
+        <Formik initialValues={{ team: "all", outOfActiveListDate: Date.now(), outOfActiveListReasons: [] }} onSubmit={setOutOfActiveList}>
+          {({ values, handleChange, handleSubmit, isSubmitting }) => (
+            <React.Fragment>
+              <ModalBody overflowY={false}>
+                <div className="tw-p-4">
+                  <div className="tw-p-4 tw-grid tw-grid-cols-3 tw-gap-2">
+                    <div>
+                      <label htmlFor="person-name">Sortie de file active de</label>
+                      <SelectCustom
+                        name="team"
+                        options={teamsWithAll}
+                        onChange={(value) => handleChange({ currentTarget: { value, name: "team" } })}
+                        value={teamsWithAll.find((t) => t._id === values.team)}
+                        getOptionValue={(team) => team._id}
+                        getOptionLabel={(team) => team.name}
+                        isDisabled={false}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="person-select-outOfActiveListReasons">Motif(s) de sortie </label>
+                      <SelectCustom
+                        options={fieldsPersonsCustomizableOptions
+                          .find((f) => f.name === "outOfActiveListReasons")
+                          .options?.map((_option) => ({ value: _option, label: _option }))}
+                        name="outOfActiveListReasons"
+                        onChange={(values) => handleChange({ currentTarget: { value: values.map((v) => v.value), name: "outOfActiveListReasons" } })}
+                        isClearable={false}
+                        isMulti
+                        inputId="person-select-outOfActiveListReasons"
+                        classNamePrefix="person-select-outOfActiveListReasons"
+                        value={values.outOfActiveListReasons?.map((_option) => ({ value: _option, label: _option })) || []}
+                        placeholder={"Choisir..."}
+                        getOptionValue={(i) => i.value}
+                        getOptionLabel={(i) => i.label}
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="person-birthdate">Date de sortie de file active</label>
                       <div>
                         <DatePicker id="outOfActiveListDate" defaultValue={values.outOfActiveListDate} onChange={handleChange} />
                       </div>
-                    </FormGroup>
-                  </Col>
-                </Row>
-                <br />
-                <div className="tw-mt-4 tw-flex tw-justify-end">
-                  <ButtonCustom
-                    onClick={() => !isSubmitting && handleSubmit()}
-                    disabled={!!isSubmitting}
-                    title={isSubmitting ? "Sauvegarde..." : "Sauvegarder"}
-                  />
+                    </div>
+                  </div>
                 </div>
-              </React.Fragment>
-            )}
-          </Formik>
-        </ModalBody>
-      </Modal>
+              </ModalBody>
+              <ModalFooter>
+                <ButtonCustom title="Annuler" type="button" onClick={() => setOpen(false)} color="secondary" />
+                <ButtonCustom title="Valider" type="submit" onClick={handleSubmit} color="primary" disabled={isSubmitting} />
+              </ModalFooter>
+            </React.Fragment>
+          )}
+        </Formik>
+      </ModalContainer>
     </>
   );
 };

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -77,24 +77,21 @@ const OutOfActiveList = ({ person }) => {
         toast.success(person.name + " est hors de la file active");
       }
     } else {
+      if (person.assignedTeams.length === 1) {
+        return toast.error("Une personne doit être suivie par au moins une équipe");
+      }
       const historyEntry = {
         date: new Date(),
         user: user._id,
         data: {
           assignedTeams: {
             oldValue: person.assignedTeams,
-            newValue: person.assignedTeams.filter((team) => team !== data.team._id),
+            newValue: person.assignedTeams.filter((team) => team !== data.team),
           },
-          outOfTeamsReasons: [
+          outOfTeamsInformations: [
             {
-              team: data.team._id,
+              team: data.team,
               reasons: data.outOfActiveListReasons,
-              date: data.outOfActiveListDate,
-            },
-            {
-              team: data.team._id,
-              reasons: data.outOfActiveListReasons,
-              date: data.outOfActiveListDate,
             },
           ],
         },
@@ -144,7 +141,7 @@ const OutOfActiveList = ({ person }) => {
                       <SelectCustom
                         name="team"
                         options={teamsWithAll}
-                        onChange={(value) => handleChange({ currentTarget: { value, name: "team" } })}
+                        onChange={(value) => handleChange({ currentTarget: { value: value._id, name: "team" } })}
                         value={teamsWithAll.find((t) => t._id === values.team)}
                         getOptionValue={(team) => team._id}
                         getOptionLabel={(team) => team.name}
@@ -172,7 +169,12 @@ const OutOfActiveList = ({ person }) => {
                     <div>
                       <label htmlFor="person-birthdate">Date de sortie de file active</label>
                       <div>
-                        <DatePicker id="outOfActiveListDate" defaultValue={values.outOfActiveListDate} onChange={handleChange} />
+                        <DatePicker
+                          disabled={values.team !== "all"}
+                          id="outOfActiveListDate"
+                          defaultValue={values.outOfActiveListDate}
+                          onChange={handleChange}
+                        />
                       </div>
                     </div>
                   </div>

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -77,7 +77,8 @@ const OutOfActiveList = ({ person }) => {
         toast.success(person.name + " est hors de la file active");
       }
     } else {
-      if (person.assignedTeams.length === 1) {
+      const nextAssignedTeams = person.assignedTeams.filter((team) => team !== data.team);
+      if (nextAssignedTeams.length < 1) {
         return toast.error("Une personne doit être suivie par au moins une équipe");
       }
       const historyEntry = {
@@ -86,7 +87,7 @@ const OutOfActiveList = ({ person }) => {
         data: {
           assignedTeams: {
             oldValue: person.assignedTeams,
-            newValue: person.assignedTeams.filter((team) => team !== data.team),
+            newValue: nextAssignedTeams,
           },
           outOfTeamsInformations: [
             {

--- a/dashboard/src/scenes/person/OutOfActiveList.jsx
+++ b/dashboard/src/scenes/person/OutOfActiveList.jsx
@@ -98,7 +98,7 @@ const OutOfActiveList = ({ person }) => {
         },
       };
 
-      const history = [...(cleanHistory(person.history) || []), historyEntry].sort((a, b) => new Date(b.date) - new Date(a.date));
+      const history = [...(cleanHistory(person.history) || []), historyEntry];
 
       const [error] = await tryFetchExpectOk(async () =>
         API.put({

--- a/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
+++ b/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
@@ -4,12 +4,12 @@ import { currentTeamState } from "../../recoil/auth";
 import { useRecoilValue } from "recoil";
 import { PersonInstance } from "../../types/person";
 
-type outOfTeamsReason = {
+type outOfTeamsInformation = {
   team: string;
   reasons: string[];
 };
-type HistoryEntryForOutOfTeamsReasons = {
-  outOfTeamsReasons: outOfTeamsReason[];
+type HistoryEntryForOutOfTeamsInformations = {
+  outOfTeamsInformations: outOfTeamsInformation[];
 };
 
 export default function OutOfActiveListBanner({ person }: { person: PersonInstance }) {
@@ -21,16 +21,16 @@ export default function OutOfActiveListBanner({ person }: { person: PersonInstan
     for (let i = person.history.length - 1; i >= 0; i--) {
       const history = person.history[i];
       if (history.data.assignedTeams?.oldValue?.includes(team._id) && !history.data.assignedTeams?.newValue?.includes(team._id)) {
-        const outOfTeamsReasons = (
-          ((history.data as unknown as HistoryEntryForOutOfTeamsReasons).outOfTeamsReasons || []) as outOfTeamsReason[]
+        const outOfTeamsInformations = (
+          ((history.data as unknown as HistoryEntryForOutOfTeamsInformations).outOfTeamsInformations || []) as outOfTeamsInformation[]
         ).find((reason) => reason.team === team._id);
         return (
           <Alert color="warning" className="noprint">
             {person?.name} est sortie de la file active de l'équipe <b>{team.name}</b> depuis le {formatDateWithFullMonth(history.date)}
-            {outOfTeamsReasons.reasons.length ? (
+            {outOfTeamsInformations?.reasons?.length ? (
               <>
-                , pour {outOfTeamsReasons.reasons?.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
-                <b>{outOfTeamsReasons.reasons?.join(", ")}</b>
+                , pour {outOfTeamsInformations.reasons?.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
+                <b>{outOfTeamsInformations.reasons?.join(", ")}</b>
               </>
             ) : (
               ""

--- a/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
+++ b/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
@@ -1,0 +1,61 @@
+import { Alert } from "reactstrap";
+import { formatDateWithFullMonth } from "../../services/date";
+import { currentTeamState } from "../../recoil/auth";
+import { useRecoilValue } from "recoil";
+import { PersonInstance } from "../../types/person";
+
+type HistoryEntryForOutOfTeamsReasons = {
+  outOfTeamsReasons: [
+    {
+      team: string;
+      reasons: string[];
+    },
+  ];
+};
+
+export default function OutOfActiveListBanner({ person }: { person: PersonInstance }) {
+  const team = useRecoilValue(currentTeamState);
+
+  const isInSelectedTeam = person.assignedTeams?.some((assignedTeam) => assignedTeam === team._id);
+  // On vérifie si la personne est hors de la file active de l'équipe sélectionnée
+  if (!isInSelectedTeam && person.history) {
+    for (let i = person.history.length - 1; i >= 0; i--) {
+      const history = person.history[i];
+      if (history.data.assignedTeams?.oldValue?.includes(team._id) && !history.data.assignedTeams?.newValue?.includes(team._id)) {
+        const outOfTeamsReasons = (history.data as unknown as HistoryEntryForOutOfTeamsReasons).outOfTeamsReasons.find(
+          (reason) => reason.team === team._id
+        );
+        return (
+          <Alert color="warning" className="noprint">
+            {person?.name} est sortie de la file active de l'équipe <b>{team.name}</b> depuis le {formatDateWithFullMonth(history.date)}
+            {outOfTeamsReasons ? (
+              <>
+                , pour {outOfTeamsReasons.reasons?.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
+                <b>{outOfTeamsReasons.reasons?.join(", ")}</b>
+              </>
+            ) : (
+              ""
+            )}
+          </Alert>
+        );
+      }
+    }
+  }
+
+  if (person.outOfActiveList) {
+    return (
+      <Alert color="warning" className="noprint">
+        {person?.name} est en dehors de la file active
+        {person.outOfActiveListReasons?.length ? (
+          <>
+            , pour {person.outOfActiveListReasons.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
+            <b>{person.outOfActiveListReasons.join(", ")}</b>
+          </>
+        ) : (
+          ""
+        )}{" "}
+        {person.outOfActiveListDate && ` depuis le ${formatDateWithFullMonth(person.outOfActiveListDate)}`}
+      </Alert>
+    );
+  }
+}

--- a/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
+++ b/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
@@ -15,6 +15,23 @@ type HistoryEntryForOutOfTeamsInformations = {
 export default function OutOfActiveListBanner({ person }: { person: PersonInstance }) {
   const team = useRecoilValue(currentTeamState);
 
+  if (person.outOfActiveList) {
+    return (
+      <Alert color="warning" className="noprint">
+        {person?.name} est en dehors de la file active de l'organisation
+        {person.outOfActiveListReasons?.length ? (
+          <>
+            , pour {person.outOfActiveListReasons.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
+            <b>{person.outOfActiveListReasons.join(", ")}</b>
+          </>
+        ) : (
+          ""
+        )}{" "}
+        {person.outOfActiveListDate && ` depuis le ${formatDateWithFullMonth(person.outOfActiveListDate)}`}
+      </Alert>
+    );
+  }
+
   const isInSelectedTeam = person.assignedTeams?.some((assignedTeam) => assignedTeam === team._id);
   // On vérifie si la personne est hors de la file active de l'équipe sélectionnée
   if (!isInSelectedTeam && person.history) {
@@ -39,22 +56,5 @@ export default function OutOfActiveListBanner({ person }: { person: PersonInstan
         );
       }
     }
-  }
-
-  if (person.outOfActiveList) {
-    return (
-      <Alert color="warning" className="noprint">
-        {person?.name} est en dehors de la file active
-        {person.outOfActiveListReasons?.length ? (
-          <>
-            , pour {person.outOfActiveListReasons.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
-            <b>{person.outOfActiveListReasons.join(", ")}</b>
-          </>
-        ) : (
-          ""
-        )}{" "}
-        {person.outOfActiveListDate && ` depuis le ${formatDateWithFullMonth(person.outOfActiveListDate)}`}
-      </Alert>
-    );
   }
 }

--- a/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
+++ b/dashboard/src/scenes/person/OutOfActiveListBanner.tsx
@@ -4,13 +4,12 @@ import { currentTeamState } from "../../recoil/auth";
 import { useRecoilValue } from "recoil";
 import { PersonInstance } from "../../types/person";
 
+type outOfTeamsReason = {
+  team: string;
+  reasons: string[];
+};
 type HistoryEntryForOutOfTeamsReasons = {
-  outOfTeamsReasons: [
-    {
-      team: string;
-      reasons: string[];
-    },
-  ];
+  outOfTeamsReasons: outOfTeamsReason[];
 };
 
 export default function OutOfActiveListBanner({ person }: { person: PersonInstance }) {
@@ -22,13 +21,13 @@ export default function OutOfActiveListBanner({ person }: { person: PersonInstan
     for (let i = person.history.length - 1; i >= 0; i--) {
       const history = person.history[i];
       if (history.data.assignedTeams?.oldValue?.includes(team._id) && !history.data.assignedTeams?.newValue?.includes(team._id)) {
-        const outOfTeamsReasons = (history.data as unknown as HistoryEntryForOutOfTeamsReasons).outOfTeamsReasons.find(
-          (reason) => reason.team === team._id
-        );
+        const outOfTeamsReasons = (
+          ((history.data as unknown as HistoryEntryForOutOfTeamsReasons).outOfTeamsReasons || []) as outOfTeamsReason[]
+        ).find((reason) => reason.team === team._id);
         return (
           <Alert color="warning" className="noprint">
             {person?.name} est sortie de la file active de l'équipe <b>{team.name}</b> depuis le {formatDateWithFullMonth(history.date)}
-            {outOfTeamsReasons ? (
+            {outOfTeamsReasons.reasons.length ? (
               <>
                 , pour {outOfTeamsReasons.reasons?.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
                 <b>{outOfTeamsReasons.reasons?.join(", ")}</b>

--- a/dashboard/src/scenes/person/components/PersonHistory.jsx
+++ b/dashboard/src/scenes/person/components/PersonHistory.jsx
@@ -30,7 +30,6 @@ export default function PersonHistory({ person }) {
     return cleanHistory([...personHistory, ...medicalFileHistory]).sort((a, b) => new Date(b.date) - new Date(a.date));
   }, [person.history, person.medicalFile?.history, user.healthcareProfessional]);
 
-  console.log("history", history);
   return (
     <div>
       <div className="tw-my-10 tw-flex tw-items-center tw-gap-2">

--- a/dashboard/src/scenes/person/components/PersonHistory.jsx
+++ b/dashboard/src/scenes/person/components/PersonHistory.jsx
@@ -108,7 +108,6 @@ export default function PersonHistory({ person }) {
                       );
                     }
                     if (key === "outOfTeamsReasons") {
-                      console.log(value);
                       if (!Array.isArray(value)) return null;
                       return (
                         <p className="tw-flex tw-flex-col" key={key}>

--- a/dashboard/src/scenes/person/components/PersonHistory.jsx
+++ b/dashboard/src/scenes/person/components/PersonHistory.jsx
@@ -30,6 +30,7 @@ export default function PersonHistory({ person }) {
     return cleanHistory([...personHistory, ...medicalFileHistory]).sort((a, b) => new Date(b.date) - new Date(a.date));
   }, [person.history, person.medicalFile?.history, user.healthcareProfessional]);
 
+  console.log("history", history);
   return (
     <div>
       <div className="tw-my-10 tw-flex tw-items-center tw-gap-2">
@@ -103,6 +104,22 @@ export default function PersonHistory({ person }) {
                       return (
                         <p className="tw-flex tw-flex-col" key={key}>
                           <span className="tw-text-main">{formatDateWithFullMonth(value.newValue)}</span>
+                        </p>
+                      );
+                    }
+                    if (key === "outOfTeamsReasons") {
+                      console.log(value);
+                      if (!Array.isArray(value)) return null;
+                      return (
+                        <p className="tw-flex tw-flex-col" key={key}>
+                          Motifs de sortie d'équipe :{" "}
+                          {value.map(({ team, reasons }) => {
+                            return (
+                              <code className="tw-text-main" key={team}>
+                                {teams.find((t) => t._id === team)?.name} : {reasons.join(", ") || "Non renseigné"}
+                              </code>
+                            );
+                          })}
                         </p>
                       );
                     }

--- a/dashboard/src/scenes/person/components/PersonHistory.jsx
+++ b/dashboard/src/scenes/person/components/PersonHistory.jsx
@@ -106,7 +106,7 @@ export default function PersonHistory({ person }) {
                         </p>
                       );
                     }
-                    if (key === "outOfTeamsReasons") {
+                    if (key === "outOfTeamsInformations") {
                       if (!Array.isArray(value)) return null;
                       return (
                         <p className="tw-flex tw-flex-col" key={key}>

--- a/dashboard/src/scenes/person/view.jsx
+++ b/dashboard/src/scenes/person/view.jsx
@@ -19,6 +19,7 @@ import TabsNav from "../../components/tailwind/TabsNav";
 import { useDataLoader } from "../../components/DataLoader";
 import SearchInPerson from "./components/SearchInPerson";
 import { errorMessage } from "../../utils";
+import OutOfActiveListBanner from "./OutOfActiveListBanner";
 
 export default function View() {
   const { personId } = useParams();
@@ -109,20 +110,7 @@ export default function View() {
         </div>
       </div>
       <div className="tw-pt-4" data-test-id={person?.name + currentTab}>
-        {person.outOfActiveList && (
-          <Alert color="warning" className="noprint">
-            {person?.name} est en dehors de la file active
-            {person.outOfActiveListReasons?.length ? (
-              <>
-                , pour {person.outOfActiveListReasons.length > 1 ? "les motifs suivants" : "le motif suivant"} :{" "}
-                <b>{person.outOfActiveListReasons.join(", ")}</b>
-              </>
-            ) : (
-              ""
-            )}{" "}
-            {person.outOfActiveListDate && ` depuis le ${formatDateWithFullMonth(person.outOfActiveListDate)}`}
-          </Alert>
-        )}
+        <OutOfActiveListBanner person={person} />
         {currentTab === "Résumé" && <Summary person={person} />}
         {!["restricted-access"].includes(user.role) && (
           <>

--- a/e2e/persons_person-full-test-migrated-from-jest.spec.ts
+++ b/e2e/persons_person-full-test-migrated-from-jest.spec.ts
@@ -195,11 +195,11 @@ test("test", async ({ page }) => {
   await page.getByRole("button", { name: "Sortie de file active" }).click();
   await page.getByRole("button", { name: "Sauvegarder" }).click();
   await page.getByText(personName + " est hors de la file active").click();
-  await page.getByText(personName + " est en dehors de la file active depuis le").click();
+  await page.getByText(personName + " est en dehors de la file active de l'organisation depuis le").click();
   await page.getByRole("button", { name: "Réintégrer dans la file active" }).click();
   await page.getByText(personName + " est réintégré dans la file active").click();
   await page.getByRole("button", { name: "Sortie de file active" }).click();
-  await page.locator('label:has-text("Veuillez préciser le(s) motif(s) de sortieChoisir...") svg').click();
+  await page.locator(".person-select-outOfActiveListReasons__input-container").click();
   await page.locator("#react-select-outOfActiveListReasons-option-4").click();
   await page.getByRole("button", { name: "Sauvegarder" }).click();
   await page.locator(".alert-warning").getByText("Départ vers autre région").click();


### PR DESCRIPTION
En fait on va y aller pas à pas c'est plus prudent. Cette PR ajoute : 

 - La possibilité de choisir de sortir d'une équipe quand on a cliqué sur "sortie de file active"
 - L'affichage d'un bandeau quand on a quitté une équipe quelque part dans l'historique qui dit qu'on a quitté la file active de l'équipe pour telle raison (si la raison est présente)

Les étapes suivantes seront : 
 - Possibilité de rajouter une raison quand on sort d'une équipe depuis la fiche de la personne
 - (peut-être) choix de date de sortie
 - affichage dans la liste des personnes quand une personne n'est pas dans la team en cours
 - Dans l'app, afficher le bandeau aussi (je ne sais plus comment ça marche)
 - Ajouter des tests sur tout ça

Je note tout ça dans le ticket