### PR TITLE
fix: nettoyage et harmonisation des boites

### DIFF
--- a/dashboard/src/components/Card.jsx
+++ b/dashboard/src/components/Card.jsx
@@ -6,7 +6,7 @@ const Card = ({ title, count, unit, children, countId, dataTestId, help, onClick
   const props = onClick ? { onClick, type: "button", name: "card", className: "button-cancel" } : {};
   return (
     <>
-      <div className="tw-relative tw-mb-2.5 tw-flex tw-h-full tw-w-full tw-flex-col tw-items-center tw-justify-between tw-rounded-2xl tw-border tw-border-main25 tw-bg-white tw-px-3 tw-pb-10 tw-pt-6 tw-font-bold">
+      <div className="tw-relative tw-flex tw-h-full tw-w-full tw-flex-col tw-items-center tw-justify-center tw-rounded-2xl tw-border tw-border-main25 tw-bg-white tw-px-3 tw-py-6 tw-font-bold">
         {!!title && (
           <div className="tw-relative">
             <p className="tw-m-0 tw-inline-block tw-text-center tw-text-lg tw-font-medium tw-text-black">
@@ -14,11 +14,13 @@ const Card = ({ title, count, unit, children, countId, dataTestId, help, onClick
             </p>
           </div>
         )}
-        <Component {...props} className={["tw-flex tw-items-end tw-text-6xl tw-text-main", children ? "tw-mb-4" : ""].join(" ")}>
-          <span data-test-id={`${dataTestId}-${count}`} id={countId}>
-            {count}
-          </span>
-          {!!unit && <span className="tw-ml-2.5 tw-text-base">{unit}</span>}
+        <Component {...props} className={["tw-grow tw-flex tw-items-center tw-text-6xl tw-text-main tw-my-2"].join(" ")}>
+          <div className="tw-flex tw-items-end">
+            <span data-test-id={`${dataTestId}-${count}`} id={countId}>
+              {count}
+            </span>
+            {!!unit && <span className="tw-ml-2.5 tw-mb-1 tw-text-base">{unit}</span>}
+          </div>
         </Component>
         {children}
       </div>

--- a/dashboard/src/components/HelpButtonAndModal.jsx
+++ b/dashboard/src/components/HelpButtonAndModal.jsx
@@ -9,7 +9,7 @@ const HelpButtonAndModal = ({ title, help }) => {
 
   return (
     <>
-      <QuestionMarkButton title={help} aria-label={help} className="noprint tw-ml-5 tw-shrink-0" onClick={() => setHelpOpen(true)} />
+      <QuestionMarkButton title={help} aria-label={help} className="noprint tw-ml-2 tw-shrink-0" onClick={() => setHelpOpen(true)} />
       <HelpModal open={helpOpen} setOpen={setHelpOpen} title={title} help={help} />
     </>
   );

--- a/dashboard/src/scenes/stats/Blocks.jsx
+++ b/dashboard/src/scenes/stats/Blocks.jsx
@@ -2,9 +2,7 @@ import { getDuration } from "./utils";
 import Card from "../../components/Card";
 
 export const Block = ({ data, title = "Nombre de personnes suivies", help = null }) => (
-  <div className="tw-px-4 tw-py-2 md:tw-basis-1/2 lg:tw-basis-1/3">
-    <Card title={title} count={Array.isArray(data) ? String(data.length) : data} help={help} />
-  </div>
+  <Card title={title} count={Array.isArray(data) ? String(data.length) : data} help={help} />
 );
 
 export const BlockDateWithTime = ({ data, field, help }) => {

--- a/dashboard/src/scenes/stats/ConsultationsStats.jsx
+++ b/dashboard/src/scenes/stats/ConsultationsStats.jsx
@@ -54,7 +54,7 @@ export default function ConsultationsStats({ consultations, personsWithConsultat
         <summary className="tw-mx-0 tw-my-8">
           <h4 className="tw-inline tw-text-xl tw-text-black75">Global</h4>
         </summary>
-        <div className="tw-mb-5 tw-flex tw-justify-center">
+        <div className="tw-mb-5 tw-flex tw-gap-4 tw-justify-center">
           <Block
             data={consultations}
             title="Nombre de consultations"

--- a/dashboard/src/scenes/stats/CustomFieldsStats.jsx
+++ b/dashboard/src/scenes/stats/CustomFieldsStats.jsx
@@ -2,10 +2,9 @@ import { useRecoilValue } from "recoil";
 import { currentTeamState } from "../../recoil/auth";
 import { CustomResponsiveBar, CustomResponsivePie } from "./charts";
 import { BlockDateWithTime, BlockTotal } from "./Blocks";
-import Card from "../../components/Card";
 import { getMultichoiceBarData, getPieData } from "./utils";
 
-const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId = "", help, onSliceClick, totalTitleForMultiChoice }) => {
+const CustomFieldsStats = ({ customFields, data, help, onSliceClick, totalTitleForMultiChoice }) => {
   const team = useRecoilValue(currentTeamState);
 
   const customFieldsInStats = customFields
@@ -15,33 +14,17 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
 
   return (
     <>
-      <div className="-tw-mx-4 tw-flex tw-flex-wrap tw-justify-around">
-        {additionalCols.map((col) => (
-          <div className="tw-basis-1/4 tw-px-4 tw-py-2" key={col.title}>
-            {/* TODO: fix alignment. */}
-            <Card
-              title={col.title}
-              count={col.value}
-              dataTestId={dataTestId}
-              help={help?.(col.title.capitalize())}
-              onClick={col.onBlockClick ? col.onBlockClick : null}
-            >
-              <div></div>
-            </Card>
-          </div>
-        ))}
-      </div>
       {customFieldsInStats.map((field) => {
         if (["number"].includes(field.type)) {
           return (
-            <div className="tw-basis-1/4 tw-px-4 tw-py-2" key={field.name}>
+            <div className="tw-py-2" key={field.name}>
               <BlockTotal title={field.label} data={data} field={field.name} help={help?.(field.label.capitalize())} />
             </div>
           );
         }
         if (["date", "date-with-time", "duration"].includes(field.type)) {
           return (
-            <div className="tw-basis-1/4 tw-px-4 tw-py-2" key={field.name}>
+            <div className="tw-py-2" key={field.name}>
               <BlockDateWithTime data={data} field={field} help={help?.(field.label.capitalize())} />
             </div>
           );

--- a/dashboard/src/scenes/stats/GeneralStats.jsx
+++ b/dashboard/src/scenes/stats/GeneralStats.jsx
@@ -19,7 +19,7 @@ const GeneralStats = ({
       <div className="tw-flex tw-basis-full tw-items-center">
         <Filters title="Filtrer par personnes suivies:" base={filterBase} filters={filterPersons} onChange={setFilterPersons} />
       </div>
-      <div className="-tw-mx-4 tw-flex tw-flex-wrap tw-justify-around">
+      <div className="tw-grid tw-grid-cols-2 xl:tw-grid-cols-3 2xl:tw-grid-cols-4 tw-gap-4 tw-my-8">
         <Block
           data={personsCreated}
           title="Nombre de personnes créées"

--- a/dashboard/src/scenes/stats/ObservationsStats.tsx
+++ b/dashboard/src/scenes/stats/ObservationsStats.tsx
@@ -20,6 +20,7 @@ import type { CustomField } from "../../types/field";
 import type { Period } from "../../types/date";
 import type { TeamInstance } from "../../types/team";
 import type { PersonPopulated } from "../../types/person";
+import Card from "../../components/Card";
 
 interface ObservationsStatsProps {
   territories: Array<TerritoryInstance>;
@@ -121,29 +122,37 @@ const ObservationsStats = ({
     <>
       <h3 className="tw-my-5 tw-text-xl">Statistiques des observations de territoire</h3>
       <Filters base={filterBase} filters={filterObs} onChange={setFilterObs} />
-      <CustomFieldsStats
-        data={observations}
-        customFields={customFieldsObs}
-        onSliceClick={user.role === "stats-only" ? undefined : onSliceClick}
-        dataTestId="number-observations"
-        additionalCols={[
-          {
-            title: "Nombre d'observations de territoire",
-            value: observations.length,
-            onBlockClick:
+      <div>
+        <div className="tw-py-2">
+          <Card
+            title="Nombre d'observations de territoire"
+            count={observations.length}
+            dataTestId="number-observations"
+            help={`Nombre d'observations de territoire des territoires sélectionnés, dans la période définie.\n\nLa moyenne de cette données est basée sur le nombre d'observations faites.`}
+            onClick={
               user.role === "stats-only"
                 ? undefined
                 : () => {
                     setSlicedData(observations);
                     setObsModalOpened(true);
-                  },
-          },
-        ]}
-        help={(label) =>
-          `${label.capitalize()} des observations des territoires sélectionnés, dans la période définie.\n\nLa moyenne de cette données est basée sur le nombre d'observations faites.`
-        }
-        totalTitleForMultiChoice={<span className="tw-font-bold">Nombre d'observations concernées</span>}
-      />
+                  }
+            }
+            unit={undefined}
+            countId={undefined}
+          >
+            <></>
+          </Card>
+        </div>
+        <CustomFieldsStats
+          data={observations}
+          customFields={customFieldsObs}
+          onSliceClick={user.role === "stats-only" ? undefined : onSliceClick}
+          help={(label) =>
+            `${label.capitalize()} des observations des territoires sélectionnés, dans la période définie.\n\nLa moyenne de cette données est basée sur le nombre d'observations faites.`
+          }
+          totalTitleForMultiChoice={<span className="tw-font-bold">Nombre d'observations concernées</span>}
+        />
+      </div>
       <CustomResponsivePie
         title="Nombre de personnes suivies différentes rencontrées (sur les territoires)"
         help={`Répartition par territoire du nombre de personnes suivies ayant été rencontrées lors de la saisie d'une observation dans la période définie. Si une personne est rencontrée plusieurs fois sur un même territoire, elle n'est comptabilisée qu'une seule fois. Si elle est rencontrée sur deux territoires différents, elle sera comptée indépendamment sur chaque territoire.\n\nSi aucune période n'est définie, on considère l'ensemble des observations.`}

--- a/dashboard/src/scenes/stats/PersonsStats.jsx
+++ b/dashboard/src/scenes/stats/PersonsStats.jsx
@@ -109,7 +109,7 @@ export default function PersonStats({
             <summary className="tw-mx-0 tw-my-8">
               <h4 className="tw-inline tw-text-xl tw-text-black75">Général</h4>
             </summary>
-            <div className="-tw-mx-4 tw-flex tw-flex-wrap tw-justify-around">
+            <div className="tw-grid tw-grid-cols-2 2xl:tw-grid-cols-4 tw-gap-4 tw-mb-8">
               <Block data={personsForStats} title={`Nombre de ${title}`} help={firstBlockHelp} />
               <BlockCreatedAt persons={personsForStats} />
               <BlockWanderingAt persons={personsForStats} />
@@ -273,25 +273,19 @@ export default function PersonStats({
 const BlockWanderingAt = ({ persons }) => {
   persons = persons.filter((p) => Boolean(p.wanderingAt));
   if (!persons.length) {
-    return (
-      <div className="tw-basis-1/2 tw-px-4 tw-py-2 lg:tw-basis-1/3">
-        <Card title="Temps d'errance des personnes en&nbsp;moyenne" unit={"N/A"} count={0} />
-      </div>
-    );
+    return <Card title="Temps d'errance des personnes en&nbsp;moyenne" unit={"N/A"} count={0} />;
   }
   const averageWanderingAt = persons.reduce((total, person) => total + Date.parse(person.wanderingAt), 0) / (persons.length || 1);
   const durationFromNowToAverage = Date.now() - averageWanderingAt;
   const [count, unit] = getDuration(durationFromNowToAverage);
 
   return (
-    <div className="tw-basis-1/2 tw-px-4 tw-py-2 lg:tw-basis-1/3">
-      <Card
-        title="Temps d'errance des personnes en&nbsp;moyenne"
-        unit={unit}
-        count={count}
-        help={`Cela veut dire qu'en moyenne, chaque personne considérée est en rue depuis ${count} ${unit}`}
-      />
-    </div>
+    <Card
+      title="Temps d'errance des personnes en&nbsp;moyenne"
+      unit={unit}
+      count={count}
+      help={`Cela veut dire qu'en moyenne, chaque personne considérée est en rue depuis ${count} ${unit}`}
+    />
   );
 };
 
@@ -299,29 +293,25 @@ const BlockGroup = ({ title, groups }) => {
   try {
     if (!groups.length) {
       return (
-        <div className="tw-basis-1/2 tw-px-4 tw-py-2 lg:tw-basis-1/3">
-          <Card
-            title={title}
-            count={0}
-            help={`Une personne ne peut appartenir qu'à une famille. On comptabilise donc le nombre de familles dans lesquelles se trouvent les personnes concernées.\n\nSi plusieurs personnes appartiennent à la même famille, on comptabilisera seulement une seule famille.`}
-          />
-        </div>
+        <Card
+          title={title}
+          count={0}
+          help={`Une personne ne peut appartenir qu'à une famille. On comptabilise donc le nombre de familles dans lesquelles se trouvent les personnes concernées.\n\nSi plusieurs personnes appartiennent à la même famille, on comptabilisera seulement une seule famille.`}
+        />
       );
     }
 
     const avg = Math.round((groups.reduce((total, group) => total + group.relations.length, 0) / groups.length) * 100) / 100;
     return (
-      <div className="tw-basis-1/2 tw-px-4 tw-py-2 lg:tw-basis-1/3">
-        <Card
-          title={title}
-          count={groups.length}
-          help={`Une personne ne peut appartenir qu'à une famille. On comptabilise donc le nombre de familles dans lesquelles se trouvent les personnes concernées.\n\nSi plusieurs personnes appartiennent à la même famille, on comptabilisera seulement une seule famille.`}
-        >
-          <span className="font-weight-normal">
-            Taille moyenne des familles: <strong>{avg}</strong>
-          </span>
-        </Card>
-      </div>
+      <Card
+        title={title}
+        count={groups.length}
+        help={`Une personne ne peut appartenir qu'à une famille. On comptabilise donc le nombre de familles dans lesquelles se trouvent les personnes concernées.\n\nSi plusieurs personnes appartiennent à la même famille, on comptabilisera seulement une seule famille.`}
+      >
+        <span className="font-weight-normal">
+          Taille moyenne des familles: <strong>{avg}</strong>
+        </span>
+      </Card>
     );
   } catch (errorBlockTotal) {
     capture("error block total", errorBlockTotal, { title, groups });
@@ -331,11 +321,7 @@ const BlockGroup = ({ title, groups }) => {
 
 const BlockCreatedAt = ({ persons }) => {
   if (persons.length === 0) {
-    return (
-      <div className="tw-basis-1/2 tw-px-4 tw-py-2 lg:tw-basis-1/3">
-        <Card title="Temps de suivi moyen" count={"-"} />
-      </div>
-    );
+    return <Card title="Temps de suivi moyen" count={"-"} />;
   }
 
   const averageFollowedTime =
@@ -373,14 +359,12 @@ const BlockCreatedAt = ({ persons }) => {
   const [count, unit] = getDuration(averageFollowedTime);
 
   return (
-    <div className="tw-basis-1/2 tw-px-4 tw-py-2 lg:tw-basis-1/3">
-      <Card
-        title="Temps de suivi moyen"
-        unit={unit}
-        count={count}
-        help={`Cela veut dire qu'en moyenne, chaque personne considérée est suivie depuis ${count} ${unit}`}
-      />
-    </div>
+    <Card
+      title="Temps de suivi moyen"
+      unit={unit}
+      count={count}
+      help={`Cela veut dire qu'en moyenne, chaque personne considérée est suivie depuis ${count} ${unit}`}
+    />
   );
 };
 


### PR DESCRIPTION
En fait ça devenait compliqué à maintenir parce que le conditionnement de l'affichage des boites dans leur container était dans les boites elles mêmes. Maintenant c'est l'extérieur qui défini s'il y a une grille, et son formattage. Autrement dit les boites sont libre de s'afficher dans ce qu'elles veulent (ça fait du code en moins).
Et j'ai enlevé (sorti) un gros if de "additionnal column" qui complexifiait