### PR TITLE
fix: pas de limite au titre de la liste des filtres

### DIFF
--- a/dashboard/src/components/Filters.tsx
+++ b/dashboard/src/components/Filters.tsx
@@ -198,9 +198,7 @@ const Filters = ({
       </div>
       <div className="border-b noprint tw-z-10 tw-mb-4 tw-flex tw-w-full tw-flex-col tw-justify-center tw-gap-2 tw-self-center tw-border-gray-300">
         <div className="tw-flex tw-flex-wrap">
-          <div className="tw-basis-5/6">
-            <p className="tw-m-0">{title}</p>
-          </div>
+          <p className="tw-m-0">{title}</p>
         </div>
         <div className="tw-w-full">
           {filters.map((filter: Filter, index: number) => {


### PR DESCRIPTION
A priori il n'y a pas de raison au fait de limiter le titre de la liste des filtres à 5/6, ce qui faisait un affichage bizarre dans les stats

_Plus tard on pourrait même challenger que ce titre soit dans le composant_