### PR TITLE
fix: on affiche "Utilisateur supprimé" au lieu d'un espace vide

### DIFF
--- a/dashboard/src/components/UserName.jsx
+++ b/dashboard/src/components/UserName.jsx
@@ -9,7 +9,7 @@ const UserName = ({ id, wrapper = (name) => name, canAddUser = null, handleChang
   const user = users.find((u) => u._id === id);
 
   if (!user?.name) {
-    if (!canAddUser) return null;
+    if (!canAddUser) return <span className="tw-text-gray-500 tw-italic">Utilisateur supprimé</span>;
   }
   return (
     <span className={[className, "tw-text-left"].join(" ")}>


### PR DESCRIPTION
c'est par rapport à cette carte https://www.notion.so/mano-sesan/Les-documents-n-ont-pas-le-cr-par-2ba39f7854ca4544aaf7a783c3789254?pvs=4

mais je propose uen solution globale...
pas sûr de mon coup, mais j'ai l'impression que c'est une bonne idée ?