### PR TITLE
fix: meilleure gestion des requêtes avortées (failed to fetch, load failed, abort, etc.)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -27,7 +27,6 @@
     "idb-keyval": "^6.2.1",
     "libsodium": "^0.7.9",
     "libsodium-wrappers": "^0.7.9",
-    "page-lifecycle": "^0.1.2",
     "react": "^18.2.0",
     "react-datepicker": "^4.0.0",
     "react-dom": "^18.2.0",

--- a/dashboard/src/app.jsx
+++ b/dashboard/src/app.jsx
@@ -7,7 +7,6 @@ import * as Sentry from "@sentry/react";
 import { fr } from "date-fns/esm/locale";
 import { registerLocale } from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import lifecycle from "page-lifecycle";
 import Account from "./scenes/account";
 import Auth from "./scenes/auth";
 import Organisation from "./scenes/organisation";
@@ -95,10 +94,21 @@ const App = () => {
   const { refresh } = useDataLoader();
   const apiToken = API.getToken();
 
+  // Abort all pending requests (that listen to this signal)
   useEffect(() => {
-    const onWindowFocus = (e) => {
-      if (apiToken && e.newState === "active") {
-        // will force logout if session is expired
+    const abort = () => {
+      API.abortController.abort(new DOMException("Aborted by navigation", "BeforeUnloadAbortError"));
+    };
+    window.addEventListener("beforeunload", abort);
+    return () => {
+      window.removeEventListener("beforeunload", abort);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleFocus = () => {
+      if (apiToken) {
+        // Cela déclenchera un logout si la session est expirée
         tryFetch(() => API.get({ path: "/check-auth" })).then(() => {
           // On ne recharge que s'il y a une clé de chiffrement
           // Sinon ça met du bazar en cache (parce que ça va chercher des données chiffrées et que ça échoue)
@@ -108,11 +118,11 @@ const App = () => {
         });
       }
     };
-    lifecycle.addEventListener("statechange", onWindowFocus);
+    window.addEventListener("focus", handleFocus);
     return () => {
-      lifecycle.removeEventListener("statechange", onWindowFocus);
+      window.removeEventListener("focus", handleFocus);
     };
-  }, [apiToken, refresh, initialLoadIsDone]);
+  }, [initialLoadIsDone, refresh, apiToken]);
 
   const showOutdateAlertBanner = useRecoilValue(showOutdateAlertBannerState);
   const deploymentCommit = useRecoilValue(deploymentCommitState);

--- a/dashboard/src/app.jsx
+++ b/dashboard/src/app.jsx
@@ -109,7 +109,7 @@ const App = () => {
     const handleFocus = () => {
       if (apiToken) {
         // Cela déclenchera un logout si la session est expirée
-        tryFetch(() => API.get({ path: "/check-auth" })).then(() => {
+        tryFetch(() => API.getAbortable({ path: "/check-auth" })).then(() => {
           // On ne recharge que s'il y a une clé de chiffrement
           // Sinon ça met du bazar en cache (parce que ça va chercher des données chiffrées et que ça échoue)
           if (initialLoadIsDone && getHashedOrgEncryptionKey()) {

--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -154,7 +154,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   */
 
     const [userError, userResponse] = await tryFetch(() => {
-      return API.get({ path: "/user/me" });
+      return API.getAbortable({ path: "/user/me" });
     });
     if (userError || !userResponse.ok) return resetLoaderOnError(userError || userResponse.error);
     const latestOrganisation = userResponse.user.organisation;
@@ -173,7 +173,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     }
 
     const [statsError, statsResponse] = await tryFetchExpectOk(() => {
-      return API.get({
+      return API.getAbortable({
         path: "/organisation/stats",
         query: {
           organisation: organisationId,
@@ -190,7 +190,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     // Get date from server just after getting all the stats
     // We'll set the `lastLoadValue` to this date after all the data is downloaded
     const [serverDateError, serverDateResponse] = await tryFetchExpectOk(() => {
-      return API.get({ path: "/now" });
+      return API.getAbortable({ path: "/now" });
     });
     if (serverDateError) return resetLoaderOnError(serverDateError);
     const serverDate = serverDateResponse.data;
@@ -230,7 +230,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des personnes");
       async function loadPersons(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/person", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/person", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -248,7 +248,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des familles");
       async function loadGroups(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/group", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/group", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -266,7 +266,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des comptes-rendus");
       async function loadReports(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/report", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/report", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -284,7 +284,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des passages");
       async function loadPassages(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/passage", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/passage", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -302,7 +302,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des rencontres");
       async function loadRencontres(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/rencontre", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/rencontre", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -320,7 +320,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des actions");
       async function loadActions(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/action", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/action", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -338,7 +338,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des territoires");
       async function loadTerritories(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/territory", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/territory", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -356,7 +356,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des lieux");
       async function loadPlaces(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/place", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/place", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -374,7 +374,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des relations personne-lieu");
       async function loadRelPersonPlaces(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/relPersonPlace", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/relPersonPlace", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -392,7 +392,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des observations de territoire");
       async function loadObservations(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/territory-observation", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/territory-observation", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -410,7 +410,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des commentaires");
       async function loadComments(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/comment", query: { ...query, page: String(page) } });
+          return API.getAbortable({ path: "/comment", query: { ...query, page: String(page) } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -428,7 +428,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des consultations");
       async function loadConsultations(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/consultation", query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue } });
+          return API.getAbortable({
+            path: "/consultation",
+            query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue },
+          });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -446,7 +449,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des traitements");
       async function loadTreatments(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/treatment", query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue } });
+          return API.getAbortable({ path: "/treatment", query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue } });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -464,7 +467,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText("Chargement des fichiers médicaux");
       async function loadMedicalFiles(page = 0) {
         const [error, res] = await tryFetchExpectOk(async () => {
-          return API.get({ path: "/medical-file", query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue } });
+          return API.getAbortable({
+            path: "/medical-file",
+            query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue },
+          });
         });
         if (error) return resetLoaderOnError();
         const decryptedData = (await Promise.all(res.data.map((p) => decryptItem(p)))).filter((e) => e);
@@ -492,6 +498,9 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     // this can result in data corruption, we need to reset the loader
     setLastLoad(0);
     await clearCache("resetLoaderOnError");
+    // Pas de message d'erreur si la page est en train de se fermer
+    // et que l'erreur est liée à une requête annulable.
+    if (error?.name === "BeforeUnloadAbortError") return false;
     toast.error(errorMessage(error || "Désolé, une erreur est survenue lors du chargement de vos données, veuillez réessayer"), {
       onClose: () => window.location.replace("/auth"),
       autoClose: 5000,

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -5514,7 +5514,6 @@ __metadata:
     jest: "npm:^29.7.0"
     libsodium: "npm:^0.7.9"
     libsodium-wrappers: "npm:^0.7.9"
-    page-lifecycle: "npm:^0.1.2"
     postcss: "npm:^8.4.35"
     prettier: "npm:^3.2.5"
     prettier-plugin-tailwindcss: "npm:^0.5.12"
@@ -9430,13 +9429,6 @@ __metadata:
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: c36c19907734c904b16994e6535b02c36c2224d433e01a2f1ab777237f4d86e6289fd5fd464850491e940379d4606ed850c03e0f9ab600b0ebddb511312e177f
-  languageName: node
-  linkType: hard
-
-"page-lifecycle@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "page-lifecycle@npm:0.1.2"
-  checksum: 509dbbc2ad2000dffcf591f66ab13d80fb1dba9337d85c76269173f7a5c3959b5a876e3bfb1e4494f6b932c1dc02a0b5824ebd452ab1a7204d4abdf498cb27c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ça peut paraitre dingue mais j'y ai passé ma journée 😭 
Normalement ça corrige la plupart des anomalies "normales" de failed to fetch, principalement concernant les requêtes qui partent dans le vide.

- On ne fait plus de "focus" quand rafraichit la page (en cliquant sur rafraichir ou F5 ou CMD+R etc.)
- On annule les requêtes du dataloader

Pour tester je me suis mis en slow 3g et ça marche plutôt bien, j'arrive à éviter les erreurs dans la plupart des cas.