### PR TITLE
fix: erreur quand on cliquait sur "ignorer cette étape" dans le retrait d'une équipe

### DIFF
--- a/dashboard/src/scenes/person/components/EditModal.jsx
+++ b/dashboard/src/scenes/person/components/EditModal.jsx
@@ -534,7 +534,7 @@ function OutOfTeamsModal({ open, onClose, removedTeams }) {
         </div>
       </ModalBody>
       <ModalFooter>
-        <ButtonCustom color="secondary" onClick={onClose} title="Ignorer cette étape" />
+        <ButtonCustom color="secondary" onClick={() => onClose()} title="Ignorer cette étape" />
         <ButtonCustom
           color="primary"
           onClick={() => {


### PR DESCRIPTION
ça faisait une référence circulaire à un élément de DOM 🤯 