### PR TITLE
fix: test de refacto de traitement modale

### DIFF
--- a/dashboard/src/scenes/person/components/TreatmentModal.jsx
+++ b/dashboard/src/scenes/person/components/TreatmentModal.jsx
@@ -3,7 +3,7 @@ import { toast } from "react-toastify";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { useHistory, useLocation } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
-import { organisationState, userState } from "../../../recoil/auth";
+import { userState } from "../../../recoil/auth";
 import { dayjsInstance, outOfBoundariesDate } from "../../../services/date";
 import API, { tryFetchExpectOk } from "../../../services/api";
 import { allowedTreatmentFieldsInHistory, encryptTreatment } from "../../../recoil/treatments";

--- a/dashboard/src/scenes/person/components/TreatmentModal.jsx
+++ b/dashboard/src/scenes/person/components/TreatmentModal.jsx
@@ -40,7 +40,7 @@ export default function TreatmentModal() {
   const paramPersonId = searchParams.get("personId");
   const isNewTreatment = Boolean(searchParams.get("newTreatment"));
 
-  const initialTreatmentState = useMemo(() => {
+  const initialTreatment = useMemo(() => {
     if (treatmentId) {
       return {
         documents: [],
@@ -73,6 +73,7 @@ export default function TreatmentModal() {
       setStatus("idle");
       setTreatmentId(null);
       setTreatment(null);
+      setActiveTab("Informations");
     }
   }, [isNewTreatment]);
 
@@ -84,14 +85,15 @@ export default function TreatmentModal() {
       setStatus("idle");
       setTreatmentId(paramTreatmentId);
       setTreatment(null);
+      setActiveTab("Informations");
     }
   }, [paramTreatmentId]);
 
   // Chargement du traitement
   useEffect(() => {
     if (!open) return;
-    setTreatment(initialTreatmentState);
-  }, [open, initialTreatmentState]);
+    setTreatment(initialTreatment);
+  }, [open, initialTreatment]);
 
   async function handleSubmit({ newData = {}, closeOnSubmit = false }) {
     const body = { ...treatment, ...newData };
@@ -117,7 +119,7 @@ export default function TreatmentModal() {
 
     setStatus("saving");
 
-    if (!isNewTreatment && !!treatment) {
+    if (!isNewTreatment && !!initialTreatment) {
       const historyEntry = {
         date: new Date(),
         user: user._id,
@@ -125,10 +127,10 @@ export default function TreatmentModal() {
       };
       for (const key in body) {
         if (!allowedTreatmentFieldsInHistory.map((field) => field.name).includes(key)) continue;
-        if (body[key] !== treatment[key]) historyEntry.data[key] = { oldValue: treatment[key], newValue: body[key] };
+        if (body[key] !== initialTreatment[key]) historyEntry.data[key] = { oldValue: initialTreatment[key], newValue: body[key] };
       }
       if (Object.keys(historyEntry.data).length) {
-        const prevHistory = Array.isArray(treatment.history) ? treatment.history : [];
+        const prevHistory = Array.isArray(initialTreatment.history) ? initialTreatment.history : [];
         body.history = [...prevHistory, historyEntry];
       }
     }
@@ -196,7 +198,7 @@ export default function TreatmentModal() {
           </>
         }
         onClose={() => {
-          if (JSON.stringify(treatment) === JSON.stringify(initialTreatmentState)) {
+          if (JSON.stringify(treatment) === JSON.stringify(initialTreatment)) {
             setOpen(false);
             return;
           }

--- a/e2e/comments_medical.spec.ts
+++ b/e2e/comments_medical.spec.ts
@@ -32,8 +32,7 @@ test("test", async ({ page }) => {
   await page.getByLabel("Commentaire", { exact: true }).fill("Avec un commentaire avant d'enregistrer");
   await page.getByRole("button", { name: "Enregistrer" }).click();
   await page.getByRole("button", { name: "Sauvegarder" }).click();
-  await new Promise((r) => setTimeout(r, 300)); // time for dialog to close
-  await page.getByText("Avec un commentaire avant d'enregistrer").click();
+  await page.locator('[data-test-id="Manu ChaoDossier Médical"]').getByText("Avec un commentaire avant d'enregistrer").click();
   await page.getByRole("button", { name: "Commentaires (1)" }).click();
   await page
     .getByRole("dialog", { name: "Consultation (créée par User Admin Test - 1)" })
@@ -44,8 +43,7 @@ test("test", async ({ page }) => {
   await page.getByRole("button", { name: "Enregistrer" }).click();
   await page.getByText("Commentaire enregistré").click();
   await page.getByRole("button", { name: "Fermer" }).first().click();
-  await new Promise((r) => setTimeout(r, 300)); // time for dialog to close
-  await expect(page.getByText("Avec un commentaire avant d'enregistrer modifié")).toBeVisible();
+  await expect(page.locator('[data-test-id="Manu ChaoDossier Médical"]').getByText("Avec un commentaire avant d'enregistrer modifié")).toBeVisible();
   await page.getByRole("button", { name: "Passer les consultations en plein écran" }).click();
   await page.getByRole("dialog", { name: "Consultations de Manu Chao (1)" }).getByText("Une consultation- Médicale").click();
   await page.getByRole("button", { name: "Commentaires (1)" }).click();
@@ -84,8 +82,7 @@ test("test", async ({ page }) => {
   await page.getByRole("button", { name: "Enregistrer" }).click();
   await page.getByText("Commentaire enregistré").click();
   await page.getByText("Fermer").click();
-  await new Promise((r) => setTimeout(r, 300)); // time for dialog to close
-  await page.getByRole("button", { name: "Ajouter un commentaire" }).click();
+  await page.locator('[data-test-id="Manu ChaoDossier Médical"]').getByRole("button", { name: "Ajouter un commentaire" }).click();
   await page.getByLabel("Commentaire", { exact: true }).click();
   await page.getByLabel("Commentaire", { exact: true }).fill("Commentaire de dossier médical");
   await page.getByRole("dialog").getByText("Enregistrer").click();


### PR DESCRIPTION
Deux objectifs : 
- ne plus avoir de clignotement de la fenetre quand quand on la ferme (le traitement ne rechange pas d'état, de isEditing, de contenu, etc.)
- empêcher qu'on clique plein de fois sur sauvegarder et supprimer, ce qui provoquait des bugs dans sentry

Le problème s'applique aux (nouvelles) modales de Mano en général, il faudra probablement repasser un peu partout si celle là marche bien

_EDIT : mais je me demande si à terme le mieux ne serait pas de refaire complètement le système de modale cf: https://manodiscussion.slack.com/archives/D02U0FGK3TJ/p1721373304734359_