### PR TITLE
chore: plus d'info en cas d'orga mélangée dans le cache

### DIFF
--- a/dashboard/src/components/DataLoader.jsx
+++ b/dashboard/src/components/DataLoader.jsx
@@ -259,7 +259,20 @@ export function useDataLoader(options = { refreshOnMount: false }) {
           if (personsFromOtherOrgs.length) {
             // get the logs to try to understand what happened
             const logs = getDebugMixedOrgsBug();
-            capture("DataLoader: personsFromOtherOrgs", { extra: { logs } });
+            capture("DataLoader: personsFromOtherOrgs amélioré", {
+              extra: {
+                logs,
+                organisationId,
+                totalPersonsFromOtherOrgs: personsFromOtherOrgs.length,
+                personFromOtherOrg: {
+                  _id: personsFromOtherOrgs[0]?._id,
+                  organisation: personsFromOtherOrgs[0]?.organisation,
+                  createdAt: personsFromOtherOrgs[0]?.createdAt,
+                  updatedAt: personsFromOtherOrgs[0]?.updatedAt,
+                  deletedAt: personsFromOtherOrgs[0]?.deletedAt,
+                },
+              },
+            });
           }
           setPersons(newPersons);
         }


### PR DESCRIPTION
les logs dans sentry nous montrent que tout va bien, cad
- storedOrganisationId === user.organisation

or il semblerait que non puisqu'une erreur sur sentry nous dit que des personnes avec une autre `organisation` sont chargées

donc ce commit est pour avoir plus de logs