### PR TITLE
fix: tri des actions dans l'app

### DIFF
--- a/app/src/recoil/selectors.js
+++ b/app/src/recoil/selectors.js
@@ -289,7 +289,9 @@ const formatData = (data) => {
     return [
       ...actions,
       { type: 'title', title: section.title, _id: section.title },
-      ...section.data.sort((a, b) => new Date(b.dueAt) - new Date(a.dueAt)),
+      ...section.data.sort((a, b) =>
+        section.title === INCOMINGDAYS ? new Date(a.dueAt) - new Date(b.dueAt) : new Date(b.dueAt) - new Date(a.dueAt)
+      ),
     ];
   }, []);
 };


### PR DESCRIPTION
AVANT: les actions à venir sont mal triées

![image](https://github.com/user-attachments/assets/898e83a2-c14d-43c4-bac1-0e795794e23e)

APRÈS

![image](https://github.com/user-attachments/assets/0109f988-2d8a-4145-bffe-70bb9965d600)
