### PR TITLE
chore: nouveau message sentry pour les erreurs de dechiffrement

### DIFF
--- a/dashboard/src/services/encryption.js
+++ b/dashboard/src/services/encryption.js
@@ -229,7 +229,7 @@ export const decryptItem = async (item, { decryptDeleted = false, type = "" } = 
         draggable: false,
       }
     );
-    capture(`ERROR DECRYPTING ${type} ${item?._id} : ${errorDecrypt}`, {
+    capture(`ERROR DECRYPTING ${type || "ITEM"} ${item?._id} : ${errorDecrypt}`, {
       extra: { message: "ERROR DECRYPTING ITEM", item, type },
       tags: { _id: item._id },
     });

--- a/dashboard/src/services/encryption.js
+++ b/dashboard/src/services/encryption.js
@@ -229,7 +229,7 @@ export const decryptItem = async (item, { decryptDeleted = false, type = "" } = 
         draggable: false,
       }
     );
-    capture(`ERROR DECRYPTING ITEM : ${errorDecrypt}`, {
+    capture(`ERROR DECRYPTING ${type} ${item?._id} : ${errorDecrypt}`, {
       extra: { message: "ERROR DECRYPTING ITEM", item, type },
       tags: { _id: item._id },
     });


### PR DESCRIPTION
ça va nous permettre 
- de cibler l'erreur de déchiffrement sur un seul item, et d'enquêter sur cet item quand il arrive
- de ne pas se faire spammer par des problèmes résolus, comme c'est le cas actuellement