### PR TITLE
fix: quand on affichait la date de dernière intéraction, on prenait jusqu'à la date du lendemain par sécurité (car c'est en mis en cache), maintenant on met à la dernière minute de la journée en cours. Cependant, une personne qui consulte à partir de minuit sans avoir retapé son mot de passe verra les intéractions s'arrêter à avant minuit jusqu'à une prochaine reconnexion

### DIFF
--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -17,8 +17,6 @@ import { groupsState } from "./groups";
 import { territoriesState } from "./territory";
 import { extractInfosFromHistory } from "../utils/person-history";
 
-const tomorrow = dayjsInstance().add(1, "day").format("YYYY-MM-DD");
-
 const usersObjectSelector = selector({
   key: "usersObjectSelector",
   get: ({ get }) => {
@@ -85,6 +83,7 @@ export const personsObjectSelector = selector({
 export const itemsGroupedByPersonSelector = selector({
   key: "itemsGroupedByPersonSelector",
   get: ({ get }) => {
+    const endOfToday = dayjsInstance().endOf("day").toISOString();
     const persons = get(personsState);
     const personsObject = {};
     const user = get(userState);
@@ -459,7 +458,7 @@ export const itemsGroupedByPersonSelector = selector({
         // otherwise we would have a bug that consider everybody "person suivies" in every period.
       ].filter((i) => Boolean(i));
 
-      personsObject[personId].lastUpdateCheckForGDPR = personsObject[personId].interactions.filter((a) => a < tomorrow)[0];
+      personsObject[personId].lastUpdateCheckForGDPR = personsObject[personId].interactions.filter((a) => a < endOfToday)[0];
     }
     return personsObject;
   },


### PR DESCRIPTION
…