### PR TITLE
chore(typo): mettre-à-jour vs mettre à jour

### DIFF
--- a/api/src/controllers/utils.js
+++ b/api/src/controllers/utils.js
@@ -29,7 +29,7 @@ router.get("/version", async (req, res) => {
       `La nouvelle version ${MOBILE_APP_VERSION} de Mano est disponible !`,
       `Vous avez la version ${req.headers.version} actuellement sur votre téléphone.
 Nouveautés: le temps de chargement initial des données a été réduit.
-Vous pourrez aussi mettre-à-jour Mano sans sortir de l'application.
+Vous pourrez aussi mettre à jour Mano sans sortir de l'application.
 `,
       [
         { text: "Télécharger", link: `https://mano.sesan.fr/download?ts=${Date.now()}` },


### PR DESCRIPTION
En fait c'est le nom "mise-à-jour" qui peut avoir des tirets dans certains cas.
Mais pas le verbe.