### PR TITLE
fix: loading false a chaque fin de chargement

### DIFF
--- a/dashboard/src/services/dataLoader.js
+++ b/dashboard/src/services/dataLoader.js
@@ -72,7 +72,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   const [medicalFiles, setMedicalFiles] = useRecoilState(medicalFileState);
 
   useEffect(function refreshOnMountEffect() {
-    if (options.refreshOnMount && !isLoading) loadOrRefreshData(false);
+    if (options.refreshOnMount && !isLoading)
+      loadOrRefreshData(false)
+        .then(() => setIsLoading(false))
+        .catch(() => setIsLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -670,8 +673,14 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   };
 
   return {
-    refresh: () => loadOrRefreshData(false),
-    startInitialLoad: () => loadOrRefreshData(true),
+    refresh: () =>
+      loadOrRefreshData(false)
+        .then(() => setIsLoading(false))
+        .catch(() => setIsLoading(false)),
+    startInitialLoad: () =>
+      loadOrRefreshData(true)
+        .then(() => setIsLoading(false))
+        .catch(() => setIsLoading(false)),
     cleanupLoader,
     isLoading: Boolean(isLoading),
     isFullScreen: Boolean(fullScreen),


### PR DESCRIPTION
To diagnose why the loader might be stuck in the isLoading === true state, let's examine the loadOrRefreshData function and related logic. Here are some potential areas where the state might not be reset properly:
Error Handling: If an error occurs during data fetching, the resetLoaderOnError function is called. This function should reset the loader state, but if it doesn't complete successfully, isLoading might remain true.
Early Returns: There are several return false; statements in the loadOrRefreshData function. If any of these are triggered without resetting the loader state, isLoading will remain true.
Final State Reset: The function should reset the loader state at the end of a successful data load. This is done with:
   setIsLoading(false);
If this line is not reached due to an error or early return, the state will not be reset.
4. Effect Cleanup: The useEffect hook that calls loadOrRefreshData on mount should ensure that the loader state is reset if the component unmounts or if the effect is cleaned up.


merci cursor

y'aplusieurs solutions possibles, notamment un `try catch finally` dans le `loadOrRefreshData`