### PR TITLE
fix: quand on supprime un utilisateur on voyait toujours "utilisateur supprimé", il fallait recharger la page pour que le changement prenne effet, désormais c'est instantané

### DIFF
--- a/dashboard/src/scenes/user/view.jsx
+++ b/dashboard/src/scenes/user/view.jsx
@@ -8,7 +8,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import Loading from "../../components/loading";
 import SelectTeamMultiple from "../../components/SelectTeamMultiple";
 import SelectRole from "../../components/SelectRole";
-import { organisationState, usersState, userState } from "../../recoil/auth";
+import { deletedUsersState, organisationState, usersState, userState } from "../../recoil/auth";
 import API, { tryFetch, tryFetchExpectOk } from "../../services/api";
 import useTitle from "../../services/useTitle";
 import DeleteButtonAndConfirmModal from "../../components/DeleteButtonAndConfirmModal";
@@ -22,6 +22,7 @@ const View = () => {
   const history = useHistory();
   const [user, setUser] = useRecoilState(userState);
   const setUsers = useSetRecoilState(usersState);
+  const setDeletedUsers = useSetRecoilState(deletedUsersState);
   const organisation = useRecoilValue(organisationState);
   const [isReactivatingUser, setIsReactivatingUser] = useState(false);
 
@@ -194,6 +195,9 @@ const View = () => {
                     if (error) {
                       return toast.error(errorMessage(error));
                     }
+                    const { data: deletedUsers } = await API.get({ path: "/user/deleted-users" });
+                    setDeletedUsers(deletedUsers);
+                    setUsers((users) => users.filter((u) => u._id !== id));
                     toast.success("Suppression réussie");
                     history.goBack();
                   }}

--- a/dashboard/src/scenes/user/view.jsx
+++ b/dashboard/src/scenes/user/view.jsx
@@ -195,8 +195,10 @@ const View = () => {
                     if (error) {
                       return toast.error(errorMessage(error));
                     }
-                    const { data: deletedUsers } = await API.get({ path: "/user/deleted-users" });
-                    setDeletedUsers(deletedUsers);
+                    const response = await API.get({ path: "/user/deleted-users" });
+                    if (response.ok && response.data?.length) {
+                      setDeletedUsers(response.data);
+                    }
                     setUsers((users) => users.filter((u) => u._id !== id));
                     toast.success("Suppression réussie");
                     history.goBack();


### PR DESCRIPTION
je pense que ça résout le bug
- pour l'admin qui supprime la personne, ça résout le bug
- pour un utilisateur sur mano pendant ce temps là, parce qu'on ne va pas fetch les users de toutes façons, ça sera comme si cet utilisateur n'était pas encore supprimé... jusqu'au prochain login

en fait, désormais à chaque fois qu'on set `usersState`, on set aussi `deletedUsersState` donc ça devrait aller