### PR TITLE
fix: gestion des slash lors du rechiffrement (version alternative pour tester)

### DIFF
--- a/app/src/services/encryption.js
+++ b/app/src/services/encryption.js
@@ -91,9 +91,7 @@ const _encrypt_and_prepend_nonce = async (message_string_or_uint8array, key_uint
 
 const encodeContent = (content) => {
   try {
-    const purifiedContent = content
-      .replace(/[\u007F-\uFFFF]/g, (chr) => '\\u' + ('0000' + chr.charCodeAt(0).toString(16)).substr(-4))
-      .replace(/\//g, '\\/');
+    const purifiedContent = content.replace(/[\u007F-\uFFFF]/g, (chr) => '\\u' + ('0000' + chr.charCodeAt(0).toString(16)).substr(-4));
     const base64PurifiedContent = rnBase64.encode(purifiedContent);
     return base64PurifiedContent;
   } catch (e) {

--- a/e2e/global_encryption-check-all-data-type.spec.ts
+++ b/e2e/global_encryption-check-all-data-type.spec.ts
@@ -12,7 +12,7 @@ test.setTimeout(120000);
 test("test", async ({ page }) => {
   const premier = "premier-" + nanoid();
   const deuxieme = "deuxieme-" + nanoid();
-  const monAction = "monAction-" + nanoid();
+  const monAction = "monAction/Avec/Un/Slash-" + nanoid();
   const testTerritoire = "testTerritoire-" + nanoid();
 
   await loginWith(page, "admin1@example.org", "secret", "plouf");


### PR DESCRIPTION
Testé sur mobile : j'ai créé des éléments avec des slashes, modifiés des éléments existants (créé sur le web) avec des slashes et chiffré plusieurs fois l'organisation. Tout semble fonctionner.

Voir aussi la discussion ici : https://manodiscussion.slack.com/archives/D02U0FGK3TJ/p1744624996600359