### PR TITLE
feat: ajout d'une modale de chargement (avec progression) pour bloquer l'utilisation de la plateforme pendant l'envoi de documents

### DIFF
--- a/dashboard/src/app.jsx
+++ b/dashboard/src/app.jsx
@@ -45,6 +45,7 @@ import Sandbox from "./scenes/sandbox";
 import { initialLoadIsDoneState, useDataLoader } from "./services/dataLoader";
 import ObservationModal from "./components/ObservationModal";
 import OrganisationDesactivee from "./scenes/organisation-desactivee";
+import { UploadProgressProvider } from "./components/DocumentsGeneric";
 
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = import.meta.env.VITE_DISABLE_RECOIL_DUPLICATE_ATOM_KEY_CHECKING ? false : true;
 
@@ -184,6 +185,7 @@ const App = () => {
         <ConsultationModal />
         <TreatmentModal />
         <ModalConfirm />
+        <UploadProgressProvider />
         {!!user && <DataLoader />}
       </Router>
     </div>

--- a/e2e/documents_organizer.spec.ts
+++ b/e2e/documents_organizer.spec.ts
@@ -72,8 +72,7 @@ test("Documents organizer", async ({ page }) => {
     .locator("label[aria-label='Ajouter des documents']")
     .first()
     .setInputFiles(["e2e/files-to-upload/image-2.jpg", "e2e/files-to-upload/image-3.jpg"]);
-  await page.getByText("Document image-2.jpg ajouté !").click();
-  await page.getByText("Document image-3.jpg ajouté !").click();
+  await page.getByText("2 documents ajoutés !").click();
   await page.getByText("Documents enregistrés !").click();
 
   await expect(page.locator("div").filter({ hasText: "image-1.jpg" }).getByLabel("Document familial")).toBeVisible();


### PR DESCRIPTION



```mermaid
graph TD
    A["User selects/drops files"] --> B["handleFilesUpload function"]
    B --> C["Initialize upload progress"]
    C --> D["Show modal with blurred background"]
    
    D --> E["For each file:"]
    E --> F["Set status to 'uploading'"]
    F --> G["Encrypt file"]
    G --> H["Upload to API"]
    
    H --> I{Upload successful?}
    I -->|Yes| J["Set status to 'completed'"]
    I -->|No| K["Set status to 'error'"]
    
    J --> L["Update progress bar"]
    K --> L
    L --> M{More files?}
    M -->|Yes| E
    M -->|No| N["Wait 1 second"]
    N --> O["Close modal"]
    O --> P["Show success toast"]
    
    Q["UploadProgressProvider<br/>(Global component in App)"] --> R["UploadProgressModal<br/>(Renders progress UI)"]
    R --> S["Blurred background<br/>prevents user interaction"]
    
    style A fill:#e1f5fe
    style D fill:#fff3e0
    style S fill:#ffebee
    style P fill:#e8f5e8
    ```