### PR TITLE
fix: quand on modificait le champ anciennement en dur "Couverture(s) médicale(s)" ou "Structure de suivi médical" dans le dossier médical d'une personne, il n'était pas possible de cliquer sur sauvegarder (bouton grisé)

### DIFF
--- a/dashboard/src/scenes/person/components/EditModal.jsx
+++ b/dashboard/src/scenes/person/components/EditModal.jsx
@@ -64,8 +64,7 @@ export default function EditModal({ person, selectedPanel, onClose, isMedicalFil
     const personHasChanged = !isEqual(person, personFormData);
     if (!isMedicalFile) return personHasChanged;
 
-    const { structureMedical, healthInsurances, ...medicalFileDataWithoutLegacy } = medicalFileFormData;
-    const medicalFileHasChanged = !isEqual(medicalFile, medicalFileDataWithoutLegacy);
+    const medicalFileHasChanged = !isEqual(medicalFile, medicalFileFormData);
     return personHasChanged || medicalFileHasChanged;
   };
 


### PR DESCRIPTION
…