### PR TITLE
fix: les rencontres nouvellement créées dans une observation de territoire ont par défaut l'équipe de l'observation, et si on change l'équipe de l'observation, les rencontres sont modifiées avec cette équipe

### DIFF
--- a/dashboard/src/components/ObservationModal.tsx
+++ b/dashboard/src/components/ObservationModal.tsx
@@ -145,6 +145,8 @@ function ObservationContent({
     const [error, response] = observation?._id ? await updateTerritoryObs(body) : await addTerritoryObs(body);
     if (!error) {
       if (observation?._id) {
+        // When updating an existing observation, synchronize the team of all associated rencontres
+        // with the observation's team to maintain consistency
         const rencontresToUpdate = rencontresForObs.filter((r) => r.team !== observation.team);
         let rencontreUpdateSuccess = true;
         for (const r of rencontresToUpdate) {


### PR DESCRIPTION
TODO: vérifier sur une observation existante avec des rencontres existantes