### PR TITLE
chore: remplacement des modales de reactstrap par les modales tailwind

### DIFF
--- a/dashboard/src/scenes/data-import-export/ImportPersons.jsx
+++ b/dashboard/src/scenes/data-import-export/ImportPersons.jsx
@@ -191,7 +191,7 @@ export default function ImportPersons() {
         style={{ display: "none" }}
         onChange={onParseData}
       />
-      <ModalContainer open={showImportSummary} onClose={() => setShowImportSummary(false)} size="lg">
+      <ModalContainer open={showImportSummary} onClose={() => setShowImportSummary(false)} size="3xl">
         <ModalHeader title="Résumé de l'import de personnes" onClose={() => setShowImportSummary(false)} />
         <ModalBody className="tw-p-4">
           {Boolean(duplicateNames.length) ? (

--- a/dashboard/src/scenes/data-import-export/ImportStructures.jsx
+++ b/dashboard/src/scenes/data-import-export/ImportStructures.jsx
@@ -140,7 +140,7 @@ export default function ImportStructures() {
         style={{ display: "none" }}
         onChange={onParseData}
       />
-      <ModalContainer open={showImportSummary} onClose={() => setShowImportSummary(false)} size="lg">
+      <ModalContainer open={showImportSummary} onClose={() => setShowImportSummary(false)} size="3xl">
         <ModalHeader title="Résumé de l'import de contacts" onClose={() => setShowImportSummary(false)} />
         <ModalBody className="tw-p-4">
           <p>

--- a/dashboard/src/scenes/data-import-export/ImportTerritories.jsx
+++ b/dashboard/src/scenes/data-import-export/ImportTerritories.jsx
@@ -141,7 +141,7 @@ export default function ImportTerritories() {
         style={{ display: "none" }}
         onChange={onParseData}
       />
-      <ModalContainer open={showImportSummary} onClose={() => setShowImportSummary(false)} size="lg">
+      <ModalContainer open={showImportSummary} onClose={() => setShowImportSummary(false)} size="3xl">
         <ModalHeader title="Résumé de l'import de territoires" onClose={() => setShowImportSummary(false)} />
         <ModalBody className="tw-p-4">
           <p>

--- a/dashboard/src/scenes/team/list.jsx
+++ b/dashboard/src/scenes/team/list.jsx
@@ -104,7 +104,7 @@ const Create = () => {
   return (
     <div className="tw-flex tw-w-full tw-justify-end">
       <ButtonCustom type="button" color="primary" onClick={() => setOpen(true)} title="Créer une équipe" padding="12px 24px" />
-      <ModalContainer open={open} onClose={onboardingForTeams ? null : () => setOpen(false)} size="lg">
+      <ModalContainer open={open} onClose={onboardingForTeams ? null : () => setOpen(false)} size="3xl">
         <ModalHeader title={onboardingForTeams ? "Dernière étape !" : "Créer une équipe"} onClose={onboardingForTeams ? null : () => setOpen(false)} />
         <ModalBody className="tw-p-4">
           {Boolean(onboardingForTeams) && (

--- a/dashboard/src/scenes/territory/list.jsx
+++ b/dashboard/src/scenes/territory/list.jsx
@@ -202,7 +202,7 @@ export function TerritoryModal({ open, setOpen, territory = {} }) {
   const territoryTypes = useAtomValue(flattenedTerritoriesTypesSelector);
 
   return (
-    <ModalContainer open={open} onClose={() => setOpen(false)} size="lg">
+    <ModalContainer open={open} onClose={() => setOpen(false)} size="3xl">
       <ModalHeader title="Créer un territoire" onClose={() => setOpen(false)} />
       <ModalBody className="tw-p-4">
         <Formik


### PR DESCRIPTION
# Revue du Refactoring des Modaux (PR-4)

J'ai refactorisé les composants modaux pour utiliser le composant existant `tailwind/Modal.tsx` 

## Changements Effectués

### 1. Fichiers Refactorisés
Les fichiers suivants ont été mis à jour pour utiliser `ModalContainer`, `ModalHeader` et `ModalBody` de `dashboard/src/components/tailwind/Modal.tsx` :

- [list.jsx](file:///c:/Users/pzrouya/Documents/Code/mano/dashboard/src/scenes/territory/list.jsx) (Gestion des territoires)
- [list.jsx](file:///c:/Users/pzrouya/Documents/Code/mano/dashboard/src/scenes/team/list.jsx) (Gestion des équipes)
- [ImportPersons.jsx](file:///c:/Users/pzrouya/Documents/Code/mano/dashboard/src/scenes/data-import-export/ImportPersons.jsx)
- [ImportStructures.jsx](file:///c:/Users/pzrouya/Documents/Code/mano/dashboard/src/scenes/data-import-export/ImportStructures.jsx)
- [ImportTerritories.jsx](file:///c:/Users/pzrouya/Documents/Code/mano/dashboard/src/scenes/data-import-export/ImportTerritories.jsx)

### 2. Adaptation de l'API
- `isOpen` → `open`
- `toggle` → `onClose`
- Utilisation de la prop `title` dans `ModalHeader` pour une implémentation propre de l'en-tête
- Ajout d'un padding cohérent avec `className="tw-p-4"` sur `ModalBody`
