### PR TITLE
fix: "Rencontré.e par" au lieu de "Équipe en charge"

### DIFF
--- a/dashboard/src/components/ObservationModal.tsx
+++ b/dashboard/src/components/ObservationModal.tsx
@@ -329,7 +329,7 @@ function ObservationContent({
                       },
                       { title: "Commentaire", dataKey: "comment" },
                       {
-                        title: "Équipe en charge",
+                        title: "Rencontré.e par l'équipe",
                         dataKey: "team",
                         render: (rencontre) => <TagTeam teamId={rencontre?.team} />,
                       },


### PR DESCRIPTION
Quand on a vu "Équipe en charge" dans les Rencontres d'une observation, on a pensé qu'on parlait de l'équipe en charge de la personne, or c'était l'équipe qui avait rencontré la personne, différente (en l'occurence) de l'équipe en charge. D'où le renommage.

Mais ça pose une question pour tous les autres `Équipes en charge` ou `Équipe(s) en charge` dans Mano (36 occurences).
On s'est dit qu'il faudrait peut-être réserver "Équipe en charge" pour ce cas de l'équipe en charge de la personne, et le reste devrait être modifié pour refléter ce que représente l'équipe mentionnée ("Équipe(s) assignée(s) pour cette action", "Passage enregistré par l'équipe", etc.)

Ce qui, mine de rien, a un impact sur les habitudes de nos utilisateurs.
D'où ma question pour toi : on fait ce futur chantier ? ou pas ? à discuter !