### PR TITLE
fix: correction de MANO-ESPACE-2FX

### DIFF
--- a/dashboard/src/services/sentry.ts
+++ b/dashboard/src/services/sentry.ts
@@ -210,7 +210,7 @@ export const capture = (err: Error | string, context: OptionalScopeContext = {})
       } else {
         // Sanitize password fields
         const extraValueObj = extraValue as Record<string, unknown>;
-        if (extraValueObj && "password" in extraValueObj) {
+        if (extraValueObj && typeof extraValueObj === "object" && "password" in extraValueObj) {
           extraValueObj.password = "******";
         }
         newExtra[extraKey] = JSON.stringify(extraValue);


### PR DESCRIPTION
## Summary
- Corrige l'erreur "right-hand side of 'in' should be an object, got boolean"
- Ajoute une vérification `typeof extraValueObj === "object"` avant d'utiliser l'opérateur `in`
- L'opérateur `in` ne fonctionne qu'avec des objets, mais `extraValue` pouvait être un booléen ou autre type primitif

## Test plan
- [ ] Vérifier que les erreurs Sentry sont correctement capturées sans crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)