### PR TITLE
chore: replace reactstrap dropdown with Headless UI Menu in TopBar

### DIFF
--- a/dashboard/src/components/TopBar.jsx
+++ b/dashboard/src/components/TopBar.jsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { Link } from "react-router-dom";
-import { ButtonDropdown, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
+import { Menu, Transition } from "@headlessui/react";
 import logo from "../assets/logo-green-creux-plus-petit.png";
 import SelectTeam from "./SelectTeam";
 
@@ -17,7 +17,6 @@ import { logout } from "../services/logout";
 
 const TopBar = ({ onLogoClick }) => {
   const [modalCacheOpen, setModalCacheOpen] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const user = useAtomValue(userState);
   const organisation = useAtomValue(organisationState);
   const teams = useAtomValue(teamsState);
@@ -87,52 +86,131 @@ const TopBar = ({ onLogoClick }) => {
             }}
           />
         </div>
-        <div className="tw-flex tw-flex-1 tw-justify-end tw-gap-x-4 [&_.dropdown-menu.show]:tw-z-20">
+        <div className="tw-flex tw-flex-1 tw-justify-end tw-gap-x-4">
           {!["stats-only", "restricted-access"].includes(user.role) ? <Notification /> : null}
           <UnBugButton onResetCacheAndLogout={resetCacheAndLogout} />
-          <ButtonDropdown direction="down" isOpen={dropdownOpen} toggle={() => setDropdownOpen(!dropdownOpen)}>
-            <DropdownToggle className="tw-ml-2.5 !tw-inline-flex tw-flex-1 tw-items-center tw-justify-between tw-gap-x-2.5 !tw-rounded-full tw-border-main tw-bg-main !tw-px-4 tw-py-1 tw-text-xs">
-              <span>{user?.name}</span>
-              <div className="tw-inline-flex tw-h-3 tw-w-3 tw-flex-1 tw-flex-col tw-justify-between">
+          <Menu as="div" className="tw-relative tw-inline-block tw-text-left">
+            {({ open }) => (
+              <>
+                <Menu.Button className={`tw-ml-2.5 tw-inline-flex tw-flex-1 tw-items-center tw-justify-between tw-gap-x-2.5 tw-rounded-full tw-border tw-px-5 tw-py-2.5 tw-text-base tw-font-normal tw-text-white focus:tw-outline-none ${
+                  open
+                    ? 'tw-border-[#545b62] tw-bg-[#5a6268]' // Keep this style when open
+                    : 'tw-border-[#6c757d] tw-bg-[#6c757d] hover:tw-border-[#545b62] hover:tw-bg-[#5a6268]'
+                }`}>
+              <span>{user?.name} </span>
+              <div className="tw-inline-flex tw-h-4 tw-w-4 tw-flex-1 tw-flex-col tw-justify-between">
                 <div className="tw-block tw-h-px tw-w-full tw-bg-white" />
                 <div className="tw-block tw-h-px tw-w-full tw-bg-white" />
                 <div className="tw-block tw-h-px tw-w-full tw-bg-white" />
               </div>
-            </DropdownToggle>
-            <DropdownMenu>
-              <DropdownItem header disabled>
-                {user?.name} - {user.role}
-              </DropdownItem>
-              <DropdownItem divider />
-              <DropdownItem tag="a" href="/charte.pdf" target="_blank" rel="noreferrer">
-                Charte des Utilisateurs <OpenNewWindowIcon />
-              </DropdownItem>
-              <DropdownItem tag="a" href="/legal.pdf" target="_blank" rel="noreferrer">
-                Mentions Légales <OpenNewWindowIcon />
-              </DropdownItem>
-              <DropdownItem tag="a" href="/cgu.pdf" target="_blank" rel="noreferrer">
-                Conditions générales d'utilisation <OpenNewWindowIcon />
-              </DropdownItem>
-              <DropdownItem tag="a" href="/privacy.pdf" target="_blank" rel="noreferrer">
-                Politique de Confidentialité <OpenNewWindowIcon />
-              </DropdownItem>
-              <DropdownItem divider />
-              <DropdownItem tag={Link} to="/account">
-                Mon compte
-              </DropdownItem>
-              <DropdownItem
-                onClick={() => {
-                  logout().then(() => {
-                    window.localStorage.removeItem("previously-logged-in");
-                    window.location.href = "/auth";
-                  });
-                }}
-              >
-                Se déconnecter
-              </DropdownItem>
-              <DropdownItem onClick={resetCacheAndLogout}>Se déconnecter et vider le cache</DropdownItem>
-            </DropdownMenu>
-          </ButtonDropdown>
+            </Menu.Button>
+            <Transition
+              as={Fragment}
+              enter="tw-transition tw-ease-out tw-duration-100"
+              enterFrom="tw-transform tw-opacity-0 tw-scale-95"
+              enterTo="tw-transform tw-opacity-100 tw-scale-100"
+              leave="tw-transition tw-ease-in tw-duration-75"
+              leaveFrom="tw-transform tw-opacity-100 tw-scale-100"
+              leaveTo="tw-transform tw-opacity-0 tw-scale-95"
+            >
+              <Menu.Items className="tw-absolute tw-right-0 tw-z-20 tw-mt-2 tw-w-auto tw-min-w-max tw-origin-top-right tw-rounded tw-bg-white tw-shadow-lg tw-ring-1 tw-ring-black/5 focus:tw-outline-none">
+                <div className="tw-py-2 tw-px-6 tw-text-base tw-font-normal tw-text-[#6c757d] tw-border-b tw-border-gray-200 tw-whitespace-nowrap">
+                  {user?.name} - {user.role}
+                </div>
+                <div className="tw-py-1">
+                  <Menu.Item>
+                    {({ active }) => (
+                      <a
+                        href="/charte.pdf"
+                        target="_blank"
+                        rel="noreferrer"
+                        className={`tw-flex tw-items-center tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Charte des Utilisateurs <OpenNewWindowIcon />
+                      </a>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item>
+                    {({ active }) => (
+                      <a
+                        href="/legal.pdf"
+                        target="_blank"
+                        rel="noreferrer"
+                        className={`tw-flex tw-items-center tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Mentions Légales <OpenNewWindowIcon />
+                      </a>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item>
+                    {({ active }) => (
+                      <a
+                        href="/cgu.pdf"
+                        target="_blank"
+                        rel="noreferrer"
+                        className={`tw-flex tw-items-center tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Conditions générales d'utilisation <OpenNewWindowIcon />
+                      </a>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item>
+                    {({ active }) => (
+                      <a
+                        href="/privacy.pdf"
+                        target="_blank"
+                        rel="noreferrer"
+                        className={`tw-flex tw-items-center tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Politique de Confidentialité <OpenNewWindowIcon />
+                      </a>
+                    )}
+                  </Menu.Item>
+                </div>
+                <div className="tw-border-t tw-border-gray-200 tw-py-1">
+                  <Menu.Item>
+                    {({ active }) => (
+                      <Link
+                        to="/account"
+                        className={`tw-block tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Mon compte
+                      </Link>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item>
+                    {({ active }) => (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          logout().then(() => {
+                            window.localStorage.removeItem("previously-logged-in");
+                            window.location.href = "/auth";
+                          });
+                        }}
+                        className={`tw-block tw-w-full tw-text-left tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Se déconnecter
+                      </button>
+                    )}
+                  </Menu.Item>
+                  <Menu.Item>
+                    {({ active }) => (
+                      <button
+                        type="button"
+                        onClick={resetCacheAndLogout}
+                        className={`tw-block tw-w-full tw-text-left tw-px-4 tw-py-2 tw-text-sm tw-whitespace-nowrap ${active ? "tw-bg-gray-100 tw-text-gray-900" : "tw-text-gray-700"}`}
+                      >
+                        Se déconnecter et vider le cache
+                      </button>
+                    )}
+                  </Menu.Item>
+                </div>
+              </Menu.Items>
+            </Transition>
+              </>
+            )}
+          </Menu>
         </div>
       </aside>
       <div className="tw-w-full">


### PR DESCRIPTION
Cette PR remplace le dropdown reactstrap par le composant `Menu` de Headless UI dans la TopBar, conformément à notre migration vers Tailwind CSS.

### Modifications principales

**Remplacement des composants** :
   - `ButtonDropdown`, `DropdownToggle`, `DropdownMenu`, `DropdownItem` (reactstrap) → `Menu`, `Menu.Button`, `Menu.Items`, `Menu.Item` (Headless UI)
   - Suppression de l'état `dropdownOpen` car Headless UI gère l'ouverture/fermeture en interne
   - Pattern render prop `{({ active }) => (...)}` pour le style conditionnel, permettant des menus accessibles et navigables au clavier sans gestion manuelle du focus


