### PR TITLE
fix: corrige le comptage des statistiques évolutives en multi-équipes

### DIFF
--- a/dashboard/__tests__/evolutives-stats-for-persons.test.ts
+++ b/dashboard/__tests__/evolutives-stats-for-persons.test.ts
@@ -560,6 +560,112 @@ describe("Stats evolutives", () => {
     expect(computed.percentSwitched).toBe(100);
   });
 
+  describe("Multi-équipes", () => {
+    // Scénario partagé :
+    // - deux équipes sélectionnées, T1 et T2
+    // - la personne est suivie par T1 en janvier, puis par T2 en mars (pas d'affectation en février)
+    // - période de requête large : janvier → mai
+    const selectedTeamsObjectWithOwnPeriod = {
+      "team-1": { isoStartDate: "2024-01-01", isoEndDate: "2024-05-01" },
+      "team-2": { isoStartDate: "2024-01-01", isoEndDate: "2024-05-01" },
+    };
+    const assignedTeamsPeriods = {
+      all: [{ isoStartDate: "2024-01-01", isoEndDate: null }],
+      "team-1": [{ isoStartDate: "2024-01-01", isoEndDate: "2024-02-01" }],
+      "team-2": [{ isoStartDate: "2024-03-01", isoEndDate: "2024-04-01" }],
+    };
+
+    test("un changement survenu pendant une période de suivi est compté une seule fois même quand plusieurs équipes sont sélectionnées", async () => {
+      // Avant la correction, la boucle historique était rejouée une fois par période retournée
+      // par la fusion des périodes d'affectation. Un changement qui tombait dans une période
+      // postérieure était donc recompté par le passage de chaque période antérieure (dont le
+      // parcours n'était pas borné par la fin de période mais seulement par queryEnd).
+      // Ici, le changement du 15 mars tombe dans la période de suivi T2 mais était aussi vu
+      // par le parcours de T1 → il était compté deux fois. La nouvelle implémentation doit
+      // le compter une seule fois.
+      const computed = computeEvolutiveStatsForPersons({
+        startDate: "2024-01-01T00:00:00.000Z",
+        endDate: "2024-05-01T00:00:00.000Z",
+        viewAllOrganisationData: false,
+        selectedTeamsObjectWithOwnPeriod,
+        evolutiveStatsIndicatorsBase: mockedEvolutiveStatsIndicatorsBase,
+        evolutiveStatsIndicators: [
+          {
+            fieldName: "custom-2023-06-16T08-50-52-737Z",
+            fromValue: "Apatride",
+            toValue: "Française",
+            type: "enum",
+          },
+        ],
+        persons: [
+          {
+            ...personPopulated,
+            assignedTeamsPeriods,
+            "custom-2023-06-16T08-50-52-737Z": "Française",
+            history: [
+              {
+                date: dayjs("2024-03-15").toDate(),
+                data: {
+                  "custom-2023-06-16T08-50-52-737Z": {
+                    oldValue: "Apatride",
+                    newValue: "Française",
+                  },
+                },
+                user: "XXX",
+              },
+            ],
+          },
+        ],
+      });
+      expect(computed.countSwitched).toBe(1);
+      expect(computed.countPersonSwitched).toBe(1);
+      expect(computed.percentSwitched).toBe(100);
+    });
+
+    test("un changement survenu pendant un trou entre deux périodes de suivi n'est pas compté", async () => {
+      // Avant la correction, la borne haute du parcours historique était queryEnd et non la
+      // fin de période, donc un changement qui avait lieu pendant un trou (ici, en février
+      // entre les périodes T1 et T2) était compté bien qu'aucune équipe sélectionnée ne
+      // suive la personne à ce moment-là.
+      const computed = computeEvolutiveStatsForPersons({
+        startDate: "2024-01-01T00:00:00.000Z",
+        endDate: "2024-05-01T00:00:00.000Z",
+        viewAllOrganisationData: false,
+        selectedTeamsObjectWithOwnPeriod,
+        evolutiveStatsIndicatorsBase: mockedEvolutiveStatsIndicatorsBase,
+        evolutiveStatsIndicators: [
+          {
+            fieldName: "custom-2023-06-16T08-50-52-737Z",
+            fromValue: "Apatride",
+            toValue: "Française",
+            type: "enum",
+          },
+        ],
+        persons: [
+          {
+            ...personPopulated,
+            assignedTeamsPeriods,
+            "custom-2023-06-16T08-50-52-737Z": "Française",
+            history: [
+              {
+                date: dayjs("2024-02-15").toDate(),
+                data: {
+                  "custom-2023-06-16T08-50-52-737Z": {
+                    oldValue: "Apatride",
+                    newValue: "Française",
+                  },
+                },
+                user: "XXX",
+              },
+            ],
+          },
+        ],
+      });
+      expect(computed.countSwitched).toBe(0);
+      expect(computed.countPersonSwitched).toBe(0);
+    });
+  });
+
   test("If the end of the period is in the future, it should work", async () => {
     const computed = computeEvolutiveStatsForPersons({
       startDate: "2024-01-01T00:00:00.000Z",

--- a/dashboard/__tests__/mocks.ts
+++ b/dashboard/__tests__/mocks.ts
@@ -43,7 +43,7 @@ export const personPopulated: PersonPopulated = {
   interactions: [dayjs("2023-01-01").toDate()],
   lastUpdateCheckForGDPR: new Date(),
   assignedTeamsPeriods: {
-    all: [{ isoStartDate: "2023-01-01", isoEndDate: "2024-01-01" }],
+    all: [{ isoStartDate: "2023-01-01", isoEndDate: null }],
   },
 };
 

--- a/dashboard/src/atoms/evolutiveStats.ts
+++ b/dashboard/src/atoms/evolutiveStats.ts
@@ -1,5 +1,4 @@
 import { atom } from "jotai";
-import structuredClone from "@ungap/structured-clone";
 import { capture } from "../services/sentry";
 import type { PersonPopulated } from "../types/person";
 import type { CustomOrPredefinedField } from "../types/field";
@@ -135,92 +134,116 @@ export function computeEvolutiveStatsForPersons({
       selectedTeamsObjectWithOwnPeriod,
       assignedTeamsPeriods: person.assignedTeamsPeriods,
     });
-    for (const period of personPeriods) {
-      const periodStartDate = dayjsInstance(period.isoStartDate).format("YYYY-MM-DD");
-      if (periodStartDate > queryEndDateFormatted) continue;
-      const initSnapshotDate = periodStartDate > queryStartDateFormatted ? periodStartDate : queryStartDateFormatted;
-      const initSnapshot = getPersonSnapshotAtDate({
-        person,
-        snapshotDate: initSnapshotDate,
-        typesByFields,
-        onlyForFieldName: indicatorFieldName,
-        replaceNullishWithNonRenseigne: true,
-      });
-      let countSwitchedValueDuringThePeriod = 0;
+    if (personPeriods.length === 0) continue;
 
-      const currentRawValue = getValueByField(indicatorFieldName, indicatorFieldType, initSnapshot[indicatorFieldName ?? ""]);
-      let currentValue = Array.isArray(currentRawValue) ? currentRawValue : [currentRawValue].filter(Boolean);
-      let currentPerson = initSnapshot;
+    // Pre-format period bounds to YYYY-MM-DD so we can compare them against history dates directly.
+    // `mergedPersonAssignedTeamPeriodsWithQueryPeriod` returns sorted, non-overlapping periods, so we
+    // can walk them with a single cursor while iterating history chronologically.
+    const formattedPeriods = personPeriods.map((p) => ({
+      start: dayjsInstance(p.isoStartDate).format("YYYY-MM-DD"),
+      end: dayjsInstance(p.isoEndDate).format("YYYY-MM-DD"),
+    }));
 
-      for (const historyItem of person.history ?? []) {
-        const historyDate = dayjsInstance(historyItem.date).format("YYYY-MM-DD");
-        if (periodStartDate === historyDate) continue; // we don't want to take the snapshot date (it's already done before the loop)
-        if (historyDate < initSnapshotDate) continue;
-        if (historyDate > queryEndDateFormatted) break;
+    const firstPeriodStart = formattedPeriods[0].start;
+    if (firstPeriodStart > queryEndDateFormatted) continue;
 
-        let nextPerson = structuredClone(currentPerson);
-        for (const historyChangeField of Object.keys(historyItem.data)) {
-          if (historyChangeField !== indicatorFieldName) continue; // we support only one indicator for now
-          if (forbiddenPersonFieldsInHistory.includes(indicatorFieldName)) continue;
-          if (indicatorFieldName === "merge") continue;
-          const oldValue = getValueByField(indicatorFieldName, indicatorFieldType, historyItem.data[historyChangeField].oldValue);
-          const historyNewValue = getValueByField(indicatorFieldName, indicatorFieldType, historyItem.data[historyChangeField].newValue);
-          const currentPersonValue = getValueByField(indicatorFieldName, indicatorFieldType, currentPerson[historyChangeField]);
-          if (JSON.stringify(oldValue) !== JSON.stringify(currentPersonValue)) {
-            capture(new Error("Incoherent history in computeEvolutiveStatsForPersons"), {
-              extra: {
-                personPeriods,
-                periodStartDate,
-                historyDate,
-                initSnapshotDate,
-                queryEndDateFormatted,
-                historyItem,
-                historyChangeField,
-                oldValue,
-                historyNewValue,
-                currentPersonValue,
-                // currentPerson,
-                // person,
-                // initSnapshot,
-              },
-            });
-          }
+    // Single snapshot at the earliest effective start: we walk the whole history once and rely on the
+    // period cursor below to decide whether a given change should be counted. This mutualises the work
+    // that used to be duplicated across periods and also fixes two pre-existing issues:
+    //   1. switches were double-counted when a person had several disjoint periods (each period ran
+    //      its own history walk without any upper bound beyond queryEnd, so changes that occurred
+    //      during a later period were counted once per earlier period too);
+    //   2. switches that happened strictly outside any selected-team period (e.g. in a gap between
+    //      two periods, or after the person left all selected teams but before queryEnd) were counted
+    //      anyway, because the inner loop only checked queryEnd, never the period's own end.
+    const initSnapshotDate = firstPeriodStart > queryStartDateFormatted ? firstPeriodStart : queryStartDateFormatted;
+    const initSnapshot = getPersonSnapshotAtDate({
+      person,
+      snapshotDate: initSnapshotDate,
+      typesByFields,
+      onlyForFieldName: indicatorFieldName,
+      replaceNullishWithNonRenseigne: true,
+    });
 
-          if (oldValue === "") continue;
-          nextPerson = {
-            ...nextPerson,
-            [historyChangeField]: historyNewValue,
-          };
+    const currentRawValue = getValueByField(indicatorFieldName, indicatorFieldType, initSnapshot[indicatorFieldName ?? ""]);
+    let currentValue = Array.isArray(currentRawValue) ? currentRawValue : [currentRawValue].filter(Boolean);
+    let currentPerson = initSnapshot;
+    let countSwitchedForPerson = 0;
+    // Cursor into `formattedPeriods`. History is iterated chronologically and periods are sorted &
+    // non-overlapping, so we only ever advance the cursor forward → amortised O(1) membership test.
+    let periodCursor = 0;
+
+    for (const historyItem of person.history ?? []) {
+      const historyDate = dayjsInstance(historyItem.date).format("YYYY-MM-DD");
+      // Items on or before the snapshot date are already reflected in `initSnapshot` (see
+      // getPersonSnapshotAtDate: it applies every history item whose date <= snapshotDate).
+      if (historyDate <= initSnapshotDate) continue;
+      if (historyDate > queryEndDateFormatted) break;
+
+      // Shallow copy is sufficient: the loop below only reassigns top-level fields and never mutates
+      // nested values. A deep clone would be a major perf sink (see the previous commit).
+      let nextPerson = { ...currentPerson };
+      for (const historyChangeField of Object.keys(historyItem.data)) {
+        if (historyChangeField !== indicatorFieldName) continue; // we support only one indicator for now
+        if (forbiddenPersonFieldsInHistory.includes(indicatorFieldName)) continue;
+        if (indicatorFieldName === "merge") continue;
+        const oldValue = getValueByField(indicatorFieldName, indicatorFieldType, historyItem.data[historyChangeField].oldValue);
+        const historyNewValue = getValueByField(indicatorFieldName, indicatorFieldType, historyItem.data[historyChangeField].newValue);
+        const currentPersonValue = getValueByField(indicatorFieldName, indicatorFieldType, currentPerson[historyChangeField]);
+        if (JSON.stringify(oldValue) !== JSON.stringify(currentPersonValue)) {
+          capture(new Error("Incoherent history in computeEvolutiveStatsForPersons"), {
+            extra: {
+              personPeriods,
+              historyDate,
+              initSnapshotDate,
+              queryEndDateFormatted,
+              historyItem,
+              historyChangeField,
+              oldValue,
+              historyNewValue,
+              currentPersonValue,
+            },
+          });
         }
-        const nextRawValue = getValueByField(indicatorFieldName, indicatorFieldType, nextPerson[indicatorFieldName ?? ""]);
-        const nextValue = Array.isArray(nextRawValue) ? nextRawValue : [nextRawValue].filter(Boolean);
 
-        if (historyDate >= queryStartDateFormatted) {
-          // now we have the person at the date of the history item
+        if (oldValue === "") continue;
+        nextPerson = {
+          ...nextPerson,
+          [historyChangeField]: historyNewValue,
+        };
+      }
+      const nextRawValue = getValueByField(indicatorFieldName, indicatorFieldType, nextPerson[indicatorFieldName ?? ""]);
+      const nextValue = Array.isArray(nextRawValue) ? nextRawValue : [nextRawValue].filter(Boolean);
 
-          if (currentValue.includes(valueStart)) {
-            if (!nextValue.includes(valueStart)) {
-              countSwitchedValueDuringThePeriod++;
-              for (const value of nextValue) {
-                if (!personsIdsSwitchedByValue[value]) {
-                  personsIdsSwitchedByValue[value] = [];
-                }
-                personsIdsSwitchedByValue[value].push(person._id);
+      // Advance cursor past any period that ended strictly before this history date.
+      while (periodCursor < formattedPeriods.length && historyDate > formattedPeriods[periodCursor].end) {
+        periodCursor++;
+      }
+      const inSelectedTeamPeriod = periodCursor < formattedPeriods.length && historyDate >= formattedPeriods[periodCursor].start;
+
+      if (inSelectedTeamPeriod && historyDate >= queryStartDateFormatted) {
+        if (currentValue.includes(valueStart)) {
+          if (!nextValue.includes(valueStart)) {
+            countSwitchedForPerson++;
+            for (const value of nextValue) {
+              if (!personsIdsSwitchedByValue[value]) {
+                personsIdsSwitchedByValue[value] = [];
               }
+              personsIdsSwitchedByValue[value].push(person._id);
             }
           }
         }
-        currentPerson = nextPerson;
-        currentValue = nextValue;
       }
+      currentPerson = nextPerson;
+      currentValue = nextValue;
+    }
 
-      if (countSwitchedValueDuringThePeriod === 0) {
-        if (!personsIdsSwitchedByValue[valueStart]) {
-          personsIdsSwitchedByValue[valueStart] = [];
-        }
-        // FIXME: is there a bug here ? we don'tcheck if the person has the valueStart, should we ?
-        personsIdsSwitchedByValue[valueStart].push(person._id); // from `fromValue` to `fromValue`
+    if (countSwitchedForPerson === 0) {
+      if (!personsIdsSwitchedByValue[valueStart]) {
+        personsIdsSwitchedByValue[valueStart] = [];
       }
+      // FIXME: is there a bug here ? we don't check if the person has the valueStart, should we ?
+      personsIdsSwitchedByValue[valueStart].push(person._id); // from `fromValue` to `fromValue`
     }
   }
 


### PR DESCRIPTION
C'est une idée de claude sur un truc qui n'a rien à voir, il m'a alerté en trouvant un bug. J'ai dit d'accord mais je veux bien ton avis bien sûr !

Quand plusieurs équipes étaient sélectionnées sur l'affichage évolutif, le même changement pouvait être compté plusieurs fois, et des changements qui avaient lieu hors des périodes de suivi par une équipe sélectionnée étaient comptés quand même. Le résultat pouvait ainsi être largement surévalué selon la configuration des périodes d'affectation de la personne.

Le calcul pour chaque personne se fait désormais en un seul parcours de son historique, en tenant compte précisément des périodes pendant lesquelles elle est effectivement suivie par au moins une équipe sélectionnée. Chaque changement est donc compté au plus une fois, et uniquement s'il survient pendant une période de suivi. En bonus, cela rend aussi le calcul nettement plus rapide, puisqu'on ne refait plus le même travail une fois par période.