### PR TITLE
fix: la recherche globale ne filtre plus les commentaires par les données de la personne associée

### DIFF
--- a/dashboard/src/scenes/search/index.jsx
+++ b/dashboard/src/scenes/search/index.jsx
@@ -221,7 +221,7 @@ function useCommentsFilteredBySearch(search) {
   const allComments = useAtomValue(allCommentsWithPassagesAndRencontresSelector);
   return useMemo(() => {
     if (!search?.length) return [];
-    return filterBySearch(search, allComments);
+    return filterBySearch(search, allComments, ["personPopulated", "userPopulated", "actionPopulated"]);
   }, [search, allComments]);
 }
 


### PR DESCRIPTION
https://www.notion.so/mano-sesan/Bug-recherche-magique-n-affiche-pas-le-terme-cl-3358b26a1ed8803a9398d86df4e03a8e?source=copy_link