### PR TITLE
fix(app): correctifs du loader (libellés de progression, fin de chargement initial, fausse alerte clé de chiffrement)

### DIFF
--- a/expo/src/Navigators.tsx
+++ b/expo/src/Navigators.tsx
@@ -167,7 +167,7 @@ const App = () => {
   const navigationRef = useNavigationContainerRef();
   const progress = useAtomValue(progressState);
   const total = useAtomValue(totalState);
-  const { resetMMKVAndAtoms, isFullScreen, isLoading } = useDataLoader();
+  const { resetMMKVAndAtoms, isFullScreen, isLoading, loadingText } = useDataLoader();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const resetOrganisation = useSetAtom(organisationState);
   const resetUser = useSetAtom(userState);
@@ -319,7 +319,7 @@ const App = () => {
             </>
           )}
         </AppStack.Navigator>
-        <ProgressBar loading={isLoading} progress={progress} fullScreen={isFullScreen} total={total} />
+        <ProgressBar isLoading={isLoading} loadingText={loadingText} progress={progress} fullScreen={isFullScreen} total={total} />
         <APKUpdater />
         <EnvironmentIndicator />
       </NavigationContainer>

--- a/expo/src/components/APKUpdater.js
+++ b/expo/src/components/APKUpdater.js
@@ -93,7 +93,7 @@ const APKUpdater = () => {
   if (downloadProgress === 0) {
     return null;
   }
-  return <ProgressBar loading="Téléchargement de la nouvelle version..." progress={downloadProgress / 100} fullScreen={false} />;
+  return <ProgressBar isLoading loadingText="Téléchargement de la nouvelle version..." progress={downloadProgress} total={100} fullScreen={false} />;
 };
 
 export default APKUpdater;

--- a/expo/src/components/ProgressBar.js
+++ b/expo/src/components/ProgressBar.js
@@ -10,11 +10,11 @@ function randomIntFromInterval(min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-export default function ProgressBar({ loading, progress, fullScreen, total }) {
+export default function ProgressBar({ isLoading, loadingText, progress, fullScreen, total }) {
   const picture = useRef([picture1, picture3, picture2][randomIntFromInterval(0, 2)]);
   const percent = progress > -1 && total > -1 ? progress / total : 0.01;
 
-  if (!loading) return null;
+  if (!isLoading) return null;
 
   return (
     <SafeAreaView
@@ -31,7 +31,7 @@ export default function ProgressBar({ loading, progress, fullScreen, total }) {
           source={picture.current}
         />
       )}
-      <MyText className="text-white p-1.5">{loading}</MyText>
+      <MyText className="text-white p-1.5">{loadingText}</MyText>
       <View
         className={["w-full h-2", fullScreen ? "w-3/4 rounded-lg border border-white overflow-hidden m-3" : ""].join(" ")}
         fullScreen={fullScreen}

--- a/expo/src/scenes/Login/CGUsAcceptance.tsx
+++ b/expo/src/scenes/Login/CGUsAcceptance.tsx
@@ -20,7 +20,7 @@ const CGUsAcceptance = ({ navigation }: CGUsAcceptanceProps) => {
   const [loading, setLoading] = useState(false);
   const user = useAtomValue(userState);
   const setCurrentTeam = useSetAtom(currentTeamState);
-  const { startInitialLoad } = useDataLoader();
+  const { startInitialLoad, cleanupLoader } = useDataLoader();
 
   const onAccept = async () => {
     setLoading(true);
@@ -30,7 +30,7 @@ const CGUsAcceptance = ({ navigation }: CGUsAcceptanceProps) => {
         navigation.navigate("CHARTE_ACCEPTANCE");
       } else if (user?.teams?.length === 1) {
         setCurrentTeam(user.teams[0]);
-        startInitialLoad();
+        startInitialLoad().then(() => cleanupLoader());
         navigation.getParent()?.navigate("TABS_STACK");
       } else {
         navigation.navigate("TEAM_SELECTION");

--- a/expo/src/scenes/Login/CharteAcceptance.tsx
+++ b/expo/src/scenes/Login/CharteAcceptance.tsx
@@ -20,7 +20,7 @@ const CharteAcceptance = ({ navigation }: CharteAcceptanceProps) => {
   const [loading, setLoading] = useState(false);
   const user = useAtomValue(userState);
   const setCurrentTeam = useSetAtom(currentTeamState);
-  const { startInitialLoad } = useDataLoader();
+  const { startInitialLoad, cleanupLoader } = useDataLoader();
 
   const onAccept = async () => {
     setLoading(true);
@@ -28,7 +28,7 @@ const CharteAcceptance = ({ navigation }: CharteAcceptanceProps) => {
     if (response.ok) {
       if (user?.teams?.length === 1) {
         setCurrentTeam(user.teams[0]);
-        startInitialLoad();
+        startInitialLoad().then(() => cleanupLoader());
         navigation.getParent()?.navigate("TABS_STACK");
       } else {
         navigation.navigate("TEAM_SELECTION");

--- a/expo/src/scenes/Login/ForceChangePassword.tsx
+++ b/expo/src/scenes/Login/ForceChangePassword.tsx
@@ -15,10 +15,10 @@ type ForceChangePasswordProps = NativeStackScreenProps<LoginStackParamsList, "FO
 const ForceChangePassword = ({ navigation }: ForceChangePasswordProps) => {
   const user = useAtomValue(userState)!;
   const setCurrentTeam = useSetAtom(currentTeamState);
-  const { startInitialLoad } = useDataLoader();
+  const { startInitialLoad, cleanupLoader } = useDataLoader();
   const onOk = () => {
     if (user.teams?.length === 1) {
-      startInitialLoad();
+      startInitialLoad().then(() => cleanupLoader());
       setCurrentTeam(user.teams[0]);
       navigation.getParent()?.navigate("TABS_STACK");
     } else {

--- a/expo/src/scenes/Login/Login.tsx
+++ b/expo/src/scenes/Login/Login.tsx
@@ -47,7 +47,7 @@ const Login = ({ navigation }: Props) => {
   const setDeletedUsers = useSetAtom(deletedUsersState);
   const setCurrentTeam = useSetAtom(currentTeamState);
   const [storageOrganisationId, setStorageOrganisationId] = useMMKVString("organisationId");
-  const { startInitialLoad, resetMMKVAndAtoms } = useDataLoader();
+  const { startInitialLoad, cleanupLoader, resetMMKVAndAtoms } = useDataLoader();
 
   const isFocused = useIsFocused();
 
@@ -213,7 +213,7 @@ const Login = ({ navigation }: Props) => {
           navigation.navigate("CHARTE_ACCEPTANCE");
         } else if (response.user?.teams?.length === 1) {
           setCurrentTeam(response.user.teams[0]);
-          startInitialLoad();
+          startInitialLoad().then(() => cleanupLoader());
           navigation.getParent()?.navigate("TABS_STACK");
         } else {
           navigation.navigate("TEAM_SELECTION");

--- a/expo/src/scenes/Login/TeamSelection.tsx
+++ b/expo/src/scenes/Login/TeamSelection.tsx
@@ -17,11 +17,11 @@ const TeamBody = ({ onSelect }: { onSelect: () => void }) => {
   const [loading, setLoading] = useState<number | undefined>(undefined);
   const user = useAtomValue(userState)!;
   const setCurrentTeam = useSetAtom(currentTeamState);
-  const { startInitialLoad } = useDataLoader();
+  const { startInitialLoad, cleanupLoader } = useDataLoader();
 
   const onTeamSelected = async (teamIndex: number) => {
     setLoading(teamIndex);
-    startInitialLoad();
+    startInitialLoad().then(() => cleanupLoader());
     setCurrentTeam(user.teams![teamIndex]!);
     setLoading(undefined);
     onSelect();

--- a/expo/src/services/dataLoader.ts
+++ b/expo/src/services/dataLoader.ts
@@ -52,7 +52,7 @@ function setMMKVCacheItem(key: string, value: any) {
 export function useDataLoader() {
   const [fullScreen, setFullScreen] = useAtom(fullScreenState);
   const [isLoading, setIsLoading] = useAtom(isLoadingState);
-  const setLoadingText = useSetAtom(loadingTextState);
+  const [loadingText, setLoadingText] = useAtom(loadingTextState);
   const setInitialLoadIsDone = useSetAtom(initialLoadIsDoneState);
   const setProgress = useSetAtom(progressState);
   const setTotal = useSetAtom(totalState);
@@ -93,7 +93,9 @@ export function useDataLoader() {
     const latestUser = userResponse.user;
     const latestTeams = userResponse.user.orgTeams;
     const organisationId = latestOrganisation._id;
-    if (organisation?.encryptionLastUpdateAt !== latestOrganisation.encryptionLastUpdateAt) {
+    // Au tout premier login, `organisation` peut encore être `null` dans la closure (l'atom a été setté
+    // mais ce render-ci ne l'a pas encore vu). On ne compare donc qu'en refresh.
+    if (!isStartingInitialLoad && organisation?.encryptionLastUpdateAt !== latestOrganisation.encryptionLastUpdateAt) {
       Alert.alert(
         "Clé de chiffrement modifiée",
         "La clé de chiffrement a changé ou a été régénérée. Veuillez vous déconnecter et vous reconnecter avec la nouvelle clé."
@@ -694,6 +696,7 @@ export function useDataLoader() {
     resetMMKVAndAtoms,
     isLoading: Boolean(isLoading),
     isFullScreen: Boolean(fullScreen),
+    loadingText,
   };
 }
 


### PR DESCRIPTION
Il s'agit de 3 bugs remontés par Claude. Le premier c'est à propos du texte de progression qui s'affichait pas, j'ai pu le constater. Aussi, il y avait un problème à la fin du chargement initial où il faut réinitialiser les composants, c'était bien le cas dans le dashboard on le fait mais on a oublié de le faire dans l'app et comme les composants sont pas démontés, il dit que c'est bien pas un faux positif.