### PR TITLE
fix: les champs de consultations ne se mélangent plus entre les types

### DIFF
--- a/api/src/utils/custom-fields/consultations.js
+++ b/api/src/utils/custom-fields/consultations.js
@@ -1,40 +1,11 @@
+// Les 3 types de consultations par défaut démarrent sans champ : auparavant chacun
+// avait un champ `name: "description"` identique, ce qui provoquait des collisions
+// quand le handler de drag-and-drop résolvait les champs par `name` à plat sur toutes
+// les consultations (un même `name` dans plusieurs types = écrasement croisé).
 const defaultConsultationsFields = [
-  {
-    name: "Psychologique",
-    fields: [
-      {
-        name: "description",
-        type: "textarea",
-        label: "Description",
-        enabled: true,
-        showInStats: false,
-      },
-    ],
-  },
-  {
-    name: "Infirmier",
-    fields: [
-      {
-        name: "description",
-        type: "textarea",
-        label: "Description",
-        enabled: true,
-        showInStats: false,
-      },
-    ],
-  },
-  {
-    name: "Médicale",
-    fields: [
-      {
-        name: "description",
-        type: "textarea",
-        label: "Description",
-        enabled: true,
-        showInStats: false,
-      },
-    ],
-  },
+  { name: "Psychologique", fields: [] },
+  { name: "Infirmier", fields: [] },
+  { name: "Médicale", fields: [] },
 ];
 
 module.exports = {

--- a/dashboard/src/scenes/organisation/ConsultationsSettings.jsx
+++ b/dashboard/src/scenes/organisation/ConsultationsSettings.jsx
@@ -120,11 +120,25 @@ const ConsultationsSettings = () => {
 
   const onDragAndDrop = useCallback(
     async (newConsultationFields) => {
-      const flattenFields = consultationFields.reduce((allFields, type) => [...allFields, ...type.fields], []);
-      newConsultationFields = newConsultationFields.map((group) => ({
-        name: group.groupTitle,
-        fields: group.items.map((customFieldName) => flattenFields.find((f) => f.name === customFieldName)),
-      }));
+      // Plusieurs types de consultation peuvent contenir un champ avec le même `name`
+      // (typiquement le `description` historiquement présent par défaut dans Psychologique/Infirmier/Médicale).
+      // On cherche donc d'abord dans le groupe d'origine, puis on retombe sur les autres groupes
+      // pour gérer le cas (rare) d'un drag inter-groupes.
+      newConsultationFields = newConsultationFields.map((newGroup) => {
+        const originalGroupFields = consultationFields.find((g) => g.name === newGroup.groupTitle)?.fields || [];
+        const otherGroupsFields = consultationFields
+          .filter((g) => g.name !== newGroup.groupTitle)
+          .reduce((acc, type) => [...acc, ...type.fields], []);
+        return {
+          name: newGroup.groupTitle,
+          fields: newGroup.items
+            .map(
+              (customFieldName) =>
+                originalGroupFields.find((f) => f.name === customFieldName) || otherGroupsFields.find((f) => f.name === customFieldName)
+            )
+            .filter(Boolean),
+        };
+      });
       const [error, res] = await tryFetchExpectOk(async () =>
         API.put({
           path: `/organisation/${organisation._id}`,


### PR DESCRIPTION
Entièrement fait par Claude Code après analyse (je lui ai fourni toute la conf de l'organisation). Mais ça semble bien

https://www.notion.so/mano-sesan/Bug-de-champs-des-consultations-qui-communiquent-34f8b26a1ed880eb8993e5ebb5b8c299?v=3e558ea5581b4943971f77a81e808ae1&source=copy_link

## Symptôme

Sur une orga avec plusieurs types de consultations contenant un champ qui partage le même `name` interne (typiquement le `description` historiquement présent par défaut dans Psychologique / Infirmier / Médicale), un drag-and-drop sur les champs de consultation provoque la propagation des valeurs (label, type, options, etc.) du premier type vers les autres : les 3 champs `description` deviennent identiques au sortir du handler. Symptômes observés : un renommage ne « tient » pas, le label/type d'un champ revient au précédent, etc.

À noter : le bug ne provoque pas de perte de données dans le cas typique signalé (champs vides ou de type compatible), mais il peut suivant les types changer la nature d'un champ utilisé.

## Cause

Dans `dashboard/src/scenes/organisation/ConsultationsSettings.jsx`, le handler `onDragAndDrop` aplatissait tous les champs de toutes les consultations puis utilisait `flattenFields.find(f => f.name === customFieldName)` pour reconstruire chaque groupe. `.find()` renvoie la **première** occurrence, donc si plusieurs types partagent un même `name`, toutes les copies se retrouvent écrasées par la première rencontrée.

C'est exactement le cas des 3 consultations par défaut de Mano qui démarraient toutes avec un champ `name: "description"` identique : au moindre drag-and-drop, le `description` du premier type (Psychologique) écrasait celui des autres.

## Correctifs

1. **`ConsultationsSettings.jsx`** : la résolution `name → field` se fait désormais d'abord dans le groupe d'origine, avec retour vers les autres groupes uniquement en fallback (pour gérer les drags inter-groupes). Plus d'écrasement croisé entre types.

2. **`api/src/utils/custom-fields/consultations.js`** : les 3 types de consultations par défaut (Psychologique, Infirmier, Médicale) démarrent désormais sans champ. Avant, ils embarquaient tous un `description` identique qui semait des collisions à l'usage. Les nouvelles orgas auront simplement à ajouter leurs propres champs personnalisés.

## Impact orgas existantes

Aucune migration : les orgas existantes conservent leurs champs `description` (et leurs données). Le fix du handler suffit à empêcher de nouveaux écrasements ; les admins peuvent ensuite renommer / désactiver / supprimer leurs `description` orphelins comme ils le souhaitent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)